### PR TITLE
Fix wrong ddk core version in requirements.txt

### DIFF
--- a/cli/aws_ddk/__metadata__.py
+++ b/cli/aws_ddk/__metadata__.py
@@ -18,7 +18,7 @@ Source repository: https://github.com/awslabs/aws-ddk
 Documentation: TBD
 """
 
-__version__: str = "0.1.1"
+__version__: str = "0.1.2"
 __title__: str = "aws_ddk"
 __description__: str = "AWS DataOps Development Kit - CLI"
 __license__: str = "Apache-2.0"

--- a/cli/aws_ddk/data/project_templates/ddk_app/cookiecutter.json
+++ b/cli/aws_ddk/data/project_templates/ddk_app/cookiecutter.json
@@ -5,5 +5,6 @@
     "stack_file_name": "ddk_app_stack",
     "stack_name": "DdkApplicationStack",
     "ddk_version": "0.1.1",
+    "ddk_core_version": "0.1.0",
     "python_executable": "python3"
 }

--- a/cli/aws_ddk/data/project_templates/ddk_app/cookiecutter.json
+++ b/cli/aws_ddk/data/project_templates/ddk_app/cookiecutter.json
@@ -4,7 +4,7 @@
     "package_name": "ddk_app",
     "stack_file_name": "ddk_app_stack",
     "stack_name": "DdkApplicationStack",
-    "ddk_version": "0.1.1",
+    "ddk_version": "0.1.2",
     "ddk_core_version": "0.1.0",
     "python_executable": "python3"
 }

--- a/cli/aws_ddk/data/project_templates/ddk_app/{{cookiecutter.directory_name}}/app.py
+++ b/cli/aws_ddk/data/project_templates/ddk_app/{{cookiecutter.directory_name}}/app.py
@@ -4,6 +4,6 @@ import aws_cdk as cdk
 from {{cookiecutter.package_name}}.{{cookiecutter.stack_file_name}} import {{cookiecutter.stack_name}}
 
 app = cdk.App()
-{{cookiecutter.stack_name}}(app, "{{cookiecutter.stack_name}}", "dev")
+{{cookiecutter.stack_name}}(app, "{{cookiecutter.stack_name}}", "{{cookiecutter.environment_id}}")
 
 app.synth()

--- a/cli/aws_ddk/data/project_templates/ddk_app/{{cookiecutter.directory_name}}/requirements.txt
+++ b/cli/aws_ddk/data/project_templates/ddk_app/{{cookiecutter.directory_name}}/requirements.txt
@@ -1,1 +1,1 @@
-aws_ddk_core=={{cookiecutter.ddk_version}}
+aws_ddk_core=={{cookiecutter.ddk_core_version}}

--- a/cli/aws_ddk/data/project_templates/ddk_app/{{cookiecutter.directory_name}}/setup.py
+++ b/cli/aws_ddk/data/project_templates/ddk_app/{{cookiecutter.directory_name}}/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as fp:
 
 setuptools.setup(
     name="{{cookiecutter.directory_name}}",
-    version="0.1.1",
+    version="{{cookiecutter.ddk_version}}",
     description="An empty DDK Python app",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-ddk"
-version = "0.1.1"
+version = "0.1.2"
 description = "AWS DataOps Development Kit - CLI"
 authors = [
     "AWS Professional Services <aws-proserve-opensource@amazon.com>"

--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = False
 tag = False
 tag_name = {new_version}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- requirements.txt is pointing to the CLI ddk version when it should be pointing to core

- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
