### PR TITLE
Adding 'latest' docs build to main branch workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,6 +12,15 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
+      - name: Release 🌱
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          pushd core; poetry export -f requirements.txt --output ../docs/source/requirements_core.txt --without-hashes; popd
+          pushd cli; poetry export -f requirements.txt --output ../docs/source/requirements_cli.txt --without-hashes; popd
+          cd docs/source && pip install -r requirements_core.txt -r requirements_cli.txt -r requirements.txt
+          cd ../
+          ./bin/build_docs.sh latest
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -20,8 +20,8 @@
                     <ul>
                         <li><a class="nav-title" href="/aws-ddk/">AWS DDK</a></li>
                         <li><a class="nav-item"  href="{{ site.workshop_url }}" aria-haspopup="true">Workshop</a></li>
-                        <li><a class="nav-item"  href="/aws-ddk/release/{{ site.data.versions.last | map: 'root' }}/how-to" aria-haspopup="true">How To</a>
-                        <li><a class="nav-item"  href="/aws-ddk/release/{{ site.data.versions.last | map: 'root' }}/api" target=”_blank” rel="noreferrer noopener" aria-haspopup="true">API Documentation</i></a>
+                        <li><a class="nav-item"  href="/aws-ddk/release/latest/how-to" aria-haspopup="true">How To</a>
+                        <li><a class="nav-item"  href="/aws-ddk/release/latest/api" target=”_blank” rel="noreferrer noopener" aria-haspopup="true">API Documentation</i></a>
                     </ul>
                 </nav>
             </div>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -29,7 +29,7 @@ layout: default
                         </div>
                         <div class="release-links">
                             <div>Current Version:</div>
-                            <div><a class="highlight-link" href="/aws-ddk/release/{{ site.data.versions.last | map: 'root' }}"><b>{{ site.data.versions.last | map: 'name' }}</b></a></div>
+                            <div><a class="highlight-link" href="/aws-ddk/release/latest"><b>Latest</b></a></div>
                             <div>・</div>
                             <div><a class="highlight-link" href="/aws-ddk/releases">All Releases</a></div>
                         </div>


### PR DESCRIPTION
### Feature or Bugfix
- Feature: Adding `latest` build of documentation to main branch

### Detail
- Every push to branch: `main` and `path_filter: docs/**` will trigger a build of the documentation to store under the root `release/latest`

### Validation 

<img width="1026" alt="Screen Shot 2022-02-24 at 10 21 36 AM" src="https://user-images.githubusercontent.com/6465221/155584930-9d65d63b-a4a7-4e5d-84bd-f6f003c05915.png">
<img width="1188" alt="Screen Shot 2022-02-24 at 10 21 45 AM" src="https://user-images.githubusercontent.com/6465221/155584943-d01d9290-5044-477d-9b78-edf2f5f17904.png">





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
