### PR TITLE
add security checks and test stages to CICD pipeline construct

### DIFF
--- a/cli/aws_ddk/data/project_templates/ddk_app/{{cookiecutter.directory_name}}/test.sh
+++ b/cli/aws_ddk/data/project_templates/ddk_app/{{cookiecutter.directory_name}}/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+# call tests for your code below
+
+# pytest tests/unit/my_test.py

--- a/core/aws_ddk_core/cicd/__init__.py
+++ b/core/aws_ddk_core/cicd/__init__.py
@@ -12,11 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from aws_ddk_core.cicd.actions import get_code_commit_source_action, get_synth_action
+from aws_ddk_core.cicd.actions import (
+    get_bandit_action,
+    get_cfn_nag_action,
+    get_code_commit_source_action,
+    get_synth_action,
+)
 from aws_ddk_core.cicd.pipeline import CICDPipelineStack
 
 __all__ = [
     "CICDPipelineStack",
     "get_code_commit_source_action",
     "get_synth_action",
+    "get_cfn_nag_action",
+    "get_bandit_action",
 ]

--- a/core/aws_ddk_core/cicd/__init__.py
+++ b/core/aws_ddk_core/cicd/__init__.py
@@ -17,6 +17,7 @@ from aws_ddk_core.cicd.actions import (
     get_cfn_nag_action,
     get_code_commit_source_action,
     get_synth_action,
+    get_tests_action,
 )
 from aws_ddk_core.cicd.pipeline import CICDPipelineStack
 
@@ -26,4 +27,5 @@ __all__ = [
     "get_synth_action",
     "get_cfn_nag_action",
     "get_bandit_action",
+    "get_tests_action",
 ]

--- a/core/aws_ddk_core/cicd/actions.py
+++ b/core/aws_ddk_core/cicd/actions.py
@@ -16,7 +16,7 @@ from typing import Any, List, Optional
 
 from aws_cdk.aws_codecommit import Repository
 from aws_cdk.aws_iam import PolicyStatement
-from aws_cdk.pipelines import CodeBuildStep, CodePipelineSource
+from aws_cdk.pipelines import CodeBuildStep, CodePipelineSource, ShellStep
 from aws_ddk_core.cicd._utils import _get_codeartifact_policy_statements
 from constructs import Construct
 
@@ -109,4 +109,55 @@ def get_synth_action(
         install_commands=install_commands,
         commands=["cdk synth"],
         role_policy_statements=role_policy_statements,
+    )
+
+
+def get_cfn_nag_action(code_pipeline_source: CodePipelineSource, stage_name: Optional[str] = "CFNNag") -> ShellStep:
+    """
+    Get CFN Nag action.
+
+    Parameters
+    ----------
+    stage_name: Optional[str]
+        Name for stage. Default is "CFNNag"
+    code_pipeline_source: CodePipelineSource
+        Code Pipeline source stage
+
+    Returns
+    -------
+    action : ShellStep
+        Codebuild step
+    """
+    return ShellStep(
+        stage_name,
+        input=code_pipeline_source,
+        install_commands=["gem install cfn-nag"],
+        commands=[
+            "fnames=$(find ./ -type f -name '*.template.json')",
+            "for f in $fnames; do cfn_nag_scan --input-path $f; done",
+        ],
+    )
+
+
+def get_bandit_action(code_pipeline_source: CodePipelineSource, stage_name: Optional[str] = "Bandit") -> ShellStep:
+    """
+    Get Bandit action.
+
+    Parameters
+    ----------
+    code_pipeline_source: CodePipelineSource
+        Code Pipeline source stage
+    stage_name: Optional[str]
+        Name for stage. Default is "Bandit"
+
+    Returns
+    -------
+    action : CodeBuildStep
+        Synth action
+    """
+    return ShellStep(
+        stage_name,
+        input=code_pipeline_source,
+        install_commands=["pip install bandit"],
+        commands=["bandit -r ./orion*"],
     )

--- a/core/aws_ddk_core/cicd/actions.py
+++ b/core/aws_ddk_core/cicd/actions.py
@@ -190,7 +190,7 @@ def get_tests_action(
         Test action
     """
     install_commands: List[str] = []
-    commands = ["./test.sh || echo 'no test script'"] if commands is None else commands
+    commands = ["./test.sh"] if commands is None else commands
     install_commands.extend(
         [
             "pip install -r requirements-dev.txt",  # Note that requirements-dev.txt can be an empty file

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -13,13 +13,19 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from aws_cdk import Environment, Stage
 from aws_cdk.aws_iam import PolicyStatement
-from aws_cdk.pipelines import CodeBuildStep, CodePipeline, CodePipelineSource, ManualApprovalStep, ShellStep
+from aws_cdk.pipelines import CodeBuildStep, CodePipeline, CodePipelineSource, IFileSetProducer, ManualApprovalStep
 from aws_ddk_core.base import BaseStack
-from aws_ddk_core.cicd import get_bandit_action, get_cfn_nag_action, get_code_commit_source_action, get_synth_action
+from aws_ddk_core.cicd import (
+    get_bandit_action,
+    get_cfn_nag_action,
+    get_code_commit_source_action,
+    get_synth_action,
+    get_tests_action,
+)
 from aws_ddk_core.config import Config
 from constructs import Construct
 from marshmallow import Schema, fields
@@ -222,11 +228,9 @@ class CICDPipelineStack(BaseStack):
         stage_id: str,
         stage: Stage,
         manual_approvals: Optional[bool] = False,
-        security_lint: Optional[bool] = False,
     ) -> "CICDPipelineStack":
         """
         Add application stage to the CICD pipeline. This stage deploys your application infrastructure.
-
         Parameters
         ----------
         stage_id: str
@@ -235,29 +239,100 @@ class CICDPipelineStack(BaseStack):
             Application stage instance
         manual_approvals: Optional[bool]
             Configure manual approvals. False by default
-        security_lint: Optional[bool]
-            Configure security linting. False by default
-
         Returns
         -------
         pipeline : CICDPipelineStack
             CICDPipelineStack
         """
-        pre_stage_actions: List[Union[ShellStep, ManualApprovalStep]] = []
-
         manual_approvals = manual_approvals or self._config.get_env_config(stage_id).get("manual_approvals")
-        if manual_approvals:
-            pre_stage_actions.append(ManualApprovalStep(f"PromoteTo{stage_id.title()}"))
 
-        if security_lint:
-            pre_stage_actions.append(
-                [
-                    get_cfn_nag_action(code_pipeline_source=self._source_action),
-                    get_bandit_action(code_pipeline_source=self._source_action),
-                ]
-            )
+        self._pipeline.add_stage(
+            stage,
+            pre=[ManualApprovalStep(f"PromoteTo{stage_id.title()}")] if manual_approvals else None,
+        )
+        return self
 
-        self._pipeline.add_stage(stage, pre=pre_stage_actions)
+    def add_security_lint_stage(
+        self,
+        stage_name: Optional[str] = None,
+        cloud_assembly_file_set: Optional[IFileSetProducer] = None,
+    ) -> "CICDPipelineStack":
+        """
+        Add linting - cfn-nag, and bandit.
+
+        Parameters
+        ----------
+        stage_name: Optional[str]
+            Name of the stage
+        cloud_assembly_file_set: Optional[IFileSetProducer]
+            Cloud assembly file set producer
+
+        Returns
+        -------
+        pipeline : CICDPipeline
+            CICD pipeline
+        """
+        self._pipeline.add_wave(
+            stage_name or "SecurityLint",
+            post=[
+                get_cfn_nag_action(
+                    file_set_producer=cloud_assembly_file_set
+                    if cloud_assembly_file_set
+                    else self._pipeline.cloud_assembly_file_set
+                ),
+                get_bandit_action(code_pipeline_source=self._source_action),
+            ],
+        )
+        return self
+
+    def add_test_stage(
+        self,
+        stage_name: Optional[str] = None,
+        cloud_assembly_file_set: Optional[IFileSetProducer] = None,
+        commands: Optional[List[str]] = None,
+    ) -> "CICDPipelineStack":
+        """
+        Add test - e.g. pytest.
+
+        Parameters
+        ----------
+        stage_name: Optional[str]
+            Name of the stage
+        cloud_assembly_file_set: Optional[IFileSetProducer]
+            Cloud assembly file set
+        commands: Optional[List[str]]
+            Additional commands to run in the test. Defaults to "./test.sh" otherwise
+
+        Returns
+        -------
+        pipeline : CICDPipelineStack
+            CICD pipeline
+        """
+
+        self._pipeline.add_wave(
+            stage_name or "Tests",
+            post=[
+                get_tests_action(
+                    file_set_producer=cloud_assembly_file_set if cloud_assembly_file_set else self._source_action,
+                    commands=commands,
+                ),
+            ],
+        )
+        return self
+
+    def add_checks(self) -> "CICDPipelineStack":
+        """
+        Add checks to the pipeline (e.g. linting, security, tests...).
+
+        Returns
+        -------
+        pipeline : CICDPipelineStack
+            CICD pipeline
+        """
+        if self._config.get_env_config("cicd").get("execute_security_lint"):
+            self.add_security_lint_stage()
+        if self._config.get_env_config("cicd").get("execute_tests"):
+            self.add_test_stage()
         return self
 
     def synth(self) -> "CICDPipelineStack":

--- a/core/tests/unit/test_cicd_pipeline_stack.py
+++ b/core/tests/unit/test_cicd_pipeline_stack.py
@@ -219,3 +219,233 @@ def test_cicd_pipeline_simple(cdk_app: App) -> None:
             ),
         },
     )
+
+
+def test_cicd_pipeline_full(cdk_app: App) -> None:
+    pipeline_stack = (
+        CICDPipelineStack(
+            cdk_app,
+            id="dummy-pipeline",
+            environment_id="dev",
+            pipeline_name="dummy-pipeline",
+        )
+        .add_source_action(repository_name="dummy-repository")
+        .add_synth_action()
+        .build()
+        .add_security_lint_stage()
+        .add_test_stage()
+        .add_stage("dev", DevStage(cdk_app, "dev"))
+        .synth()
+    )
+    template = Template.from_stack(pipeline_stack)
+    # Check if synthesized pipeline contains source, synth, self-update, and app stage
+    template.has_resource_properties(
+        "AWS::CodePipeline::Pipeline",
+        props={
+            "Stages": Match.array_with(
+                pattern=[
+                    Match.object_like(
+                        pattern={
+                            "Name": "Source",
+                            "Actions": Match.array_with(
+                                pattern=[
+                                    Match.object_like(
+                                        pattern={
+                                            "Name": "dummy-repository",
+                                            "ActionTypeId": {
+                                                "Category": "Source",
+                                                "Provider": "CodeCommit",
+                                            },
+                                            "Configuration": {
+                                                "RepositoryName": "dummy-repository",
+                                                "BranchName": "main",
+                                            },
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                    Match.object_like(
+                        pattern={
+                            "Name": "Build",
+                            "Actions": Match.array_with(
+                                pattern=[
+                                    Match.object_like(
+                                        pattern={
+                                            "Name": "Synth",
+                                            "ActionTypeId": {
+                                                "Category": "Build",
+                                                "Provider": "CodeBuild",
+                                            },
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                    Match.object_like(
+                        pattern={
+                            "Name": "UpdatePipeline",
+                            "Actions": Match.array_with(
+                                pattern=[
+                                    Match.object_like(
+                                        pattern={
+                                            "Name": "SelfMutate",
+                                            "ActionTypeId": {
+                                                "Category": "Build",
+                                                "Provider": "CodeBuild",
+                                            },
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                    Match.object_like(
+                        pattern={
+                            "Name": "SecurityLint",
+                            "Actions": Match.array_with(
+                                pattern=[
+                                    Match.object_like(
+                                        pattern={
+                                            "Name": "Bandit",
+                                            "ActionTypeId": {
+                                                "Category": "Build",
+                                                "Provider": "CodeBuild",
+                                            },
+                                        },
+                                    ),
+                                    Match.object_like(
+                                        pattern={
+                                            "Name": "CFNNag",
+                                            "ActionTypeId": {
+                                                "Category": "Build",
+                                                "Provider": "CodeBuild",
+                                            },
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                    Match.object_like(
+                        pattern={
+                            "Name": "Tests",
+                            "Actions": Match.array_with(
+                                pattern=[
+                                    Match.object_like(
+                                        pattern={
+                                            "Name": "Tests",
+                                            "ActionTypeId": {
+                                                "Category": "Build",
+                                                "Provider": "CodeBuild",
+                                            },
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                    Match.object_like(
+                        pattern={
+                            "Name": "dev",
+                        },
+                    ),
+                ],
+            ),
+        },
+    )
+    # Check if pipeline bucket is KMS-encrypted and blocks public access
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        props={
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "BlockPublicPolicy": True,
+                "IgnorePublicAcls": True,
+                "RestrictPublicBuckets": True,
+            },
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": Match.array_with(
+                    pattern=[
+                        Match.object_like(
+                            pattern={
+                                "ServerSideEncryptionByDefault": {
+                                    "SSEAlgorithm": "aws:kms",
+                                },
+                            },
+                        ),
+                    ],
+                ),
+            },
+        },
+    )
+    # Check if KMS keys are rotated
+    template.has_resource_properties(
+        "AWS::KMS::Key",
+        props={
+            "EnableKeyRotation": True,
+        },
+    )
+    # Check if all IAM roles have permissions boundary attached
+    template.has_resource_properties(
+        "AWS::IAM::Role",
+        props={
+            "AssumeRolePolicyDocument": Match.object_like(
+                pattern={
+                    "Statement": [
+                        {
+                            "Action": "sts:AssumeRole",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "codepipeline.amazonaws.com",
+                            },
+                        },
+                    ],
+                },
+            ),
+            "PermissionsBoundary": Match.object_like(
+                pattern={
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:",
+                            {"Ref": "AWS::Partition"},
+                            ":iam::111111111111:policy/ddk-dev-hnb659fds-permissions-boundary-111111111111-us-east-1",  # noqa
+                        ],
+                    ],
+                }
+            ),
+        },
+    )
+    template.has_resource_properties(
+        "AWS::IAM::Role",
+        props={
+            "AssumeRolePolicyDocument": Match.object_like(
+                pattern={
+                    "Statement": [
+                        {
+                            "Action": "sts:AssumeRole",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "codebuild.amazonaws.com",
+                            },
+                        },
+                    ],
+                },
+            ),
+            "PermissionsBoundary": Match.object_like(
+                pattern={
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:",
+                            {"Ref": "AWS::Partition"},
+                            ":iam::111111111111:policy/ddk-dev-hnb659fds-permissions-boundary-111111111111-us-east-1",  # noqa
+                        ],
+                    ],
+                }
+            ),
+        },
+    )


### PR DESCRIPTION
### Features
- Adding Security Lint Stage `add_security_lint_stage()`
- Adding Tests Stage `add_test_stage()`
- Adding Checks method to add both above stages `add_checks()`
- PyTest for full pipeline example with above methods in instantiation


### Relates
- [#28 ](https://github.com/awslabs/aws-ddk/issues/28)
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
