### PR TITLE
minor: updating pipeline and stage names to data*

### DIFF
--- a/core/aws_ddk_core/pipelines/__init__.py
+++ b/core/aws_ddk_core/pipelines/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from aws_ddk_core.pipelines.pipeline import Pipeline
-from aws_ddk_core.pipelines.stage import Stage
+from aws_ddk_core.pipelines.pipeline import DataPipeline
+from aws_ddk_core.pipelines.stage import DataStage
 
 __all__ = [
-    "Pipeline",
-    "Stage",
+    "DataPipeline",
+    "DataStage",
 ]

--- a/core/aws_ddk_core/pipelines/pipeline.py
+++ b/core/aws_ddk_core/pipelines/pipeline.py
@@ -60,7 +60,9 @@ class DataPipeline(Construct):
         self._prev_stage: Optional[DataStage] = None
         self._rules: List[Rule] = []
 
-    def add_stage(self, stage: DataStage, skip_rule: bool = False, override_rule: Optional[Rule] = None) -> "DataPipeline":
+    def add_stage(
+        self, stage: DataStage, skip_rule: bool = False, override_rule: Optional[Rule] = None
+    ) -> "DataPipeline":
         """
         Add a stage to the data pipeline.
 

--- a/core/aws_ddk_core/pipelines/pipeline.py
+++ b/core/aws_ddk_core/pipelines/pipeline.py
@@ -15,17 +15,17 @@
 from typing import List, Optional
 
 from aws_cdk.aws_events import EventPattern, IRuleTarget, Rule
-from aws_ddk_core.pipelines.stage import Stage
+from aws_ddk_core.pipelines.stage import DataStage
 from constructs import Construct
 
 
-class Pipeline(Construct):
+class DataPipeline(Construct):
     """
     Class that represents a data pipeline. Used to wire stages via Event Rules. For example:
 
     .. code-block:: python
 
-        Pipeline(self, id, description="My pipeline")
+        DataPipeline(self, id, description="My pipeline")
             .add_stage(my_lambda_stage)
             .add_stage(my_glue_stage)
 
@@ -57,10 +57,10 @@ class Pipeline(Construct):
         self.id: str = id
         self.name: Optional[str] = name
         self.description: Optional[str] = description
-        self._prev_stage: Optional[Stage] = None
+        self._prev_stage: Optional[DataStage] = None
         self._rules: List[Rule] = []
 
-    def add_stage(self, stage: Stage, skip_rule: bool = False, override_rule: Optional[Rule] = None) -> "Pipeline":
+    def add_stage(self, stage: DataStage, skip_rule: bool = False, override_rule: Optional[Rule] = None) -> "DataPipeline":
         """
         Add a stage to the data pipeline.
 
@@ -69,7 +69,7 @@ class Pipeline(Construct):
 
         Parameters
         ----------
-        stage : Stage
+        stage : DataStage
             Stage instance
         skip_rule : bool
             Skip creation of the default rule
@@ -78,8 +78,8 @@ class Pipeline(Construct):
 
         Returns
         -------
-        pipeline : Pipeline
-            Pipeline
+        pipeline : DataPipeline
+            DataPipeline
         """
         if override_rule:
             self.add_rule(override_rule=override_rule)
@@ -98,7 +98,7 @@ class Pipeline(Construct):
         event_pattern: Optional[EventPattern] = None,
         event_targets: Optional[List[IRuleTarget]] = None,
         override_rule: Optional[Rule] = None,
-    ) -> "Pipeline":
+    ) -> "DataPipeline":
         """
         Create a rule that matches specificed event pattern with the specified target.
 
@@ -115,8 +115,8 @@ class Pipeline(Construct):
 
         Returns
         -------
-        pipeline : Pipeline
-            Pipeline
+        pipeline : DataPipeline
+            DataPipeline
         """
         self._rules.append(
             override_rule

--- a/core/aws_ddk_core/pipelines/stage.py
+++ b/core/aws_ddk_core/pipelines/stage.py
@@ -19,16 +19,16 @@ from aws_cdk.aws_events import EventPattern, IRuleTarget
 from constructs import Construct
 
 
-class Stage(Construct):
+class DataStage(Construct):
     """
     Class that represents a stage within a data pipeline.
 
-    To create a Stage, inherit from this class, add infrastructure required by the stage, and implement
+    To create a DataStage, inherit from this class, add infrastructure required by the stage, and implement
     get_event_pattern and get_targets methods. For example:
 
     .. code-block:: python
 
-        class MyStage(Stage):
+        class MyStage(DataStage):
             def __init__(
                 self,
                 scope: Construct,

--- a/core/aws_ddk_core/stages/glue_transform.py
+++ b/core/aws_ddk_core/stages/glue_transform.py
@@ -27,13 +27,13 @@ from aws_cdk.aws_stepfunctions import (
     TaskInput,
 )
 from aws_cdk.aws_stepfunctions_tasks import GlueStartJobRun
-from aws_ddk_core.pipelines.stage import Stage
+from aws_ddk_core.pipelines.stage import DataStage
 from constructs import Construct
 
 
-class GlueTransformStage(Stage):
+class GlueTransformStage(DataStage):
     """
-    Class that represents a Glue Transform DDK Stage.
+    Class that represents a Glue Transform DDK DataStage.
     """
 
     def __init__(

--- a/core/aws_ddk_core/stages/s3_event.py
+++ b/core/aws_ddk_core/stages/s3_event.py
@@ -17,12 +17,12 @@ from typing import Any, Dict, List, Optional
 from aws_cdk.aws_cloudtrail import S3EventSelector, Trail
 from aws_cdk.aws_events import EventPattern, IRuleTarget
 from aws_cdk.aws_s3 import Bucket, IBucket
-from aws_ddk_core.pipelines import Stage
+from aws_ddk_core.pipelines import DataStage
 from aws_ddk_core.resources import S3Factory
 from constructs import Construct
 
 
-class S3EventStage(Stage):
+class S3EventStage(DataStage):
     """
     Class that represents an S3 Event DDK Stage.
     """

--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -21,12 +21,12 @@ from aws_cdk.aws_iam import IRole
 from aws_cdk.aws_lambda import Code, IFunction, Runtime
 from aws_cdk.aws_lambda_event_sources import SqsEventSource
 from aws_cdk.aws_sqs import DeadLetterQueue, IQueue
-from aws_ddk_core.pipelines.stage import Stage
+from aws_ddk_core.pipelines.stage import DataStage
 from aws_ddk_core.resources import LambdaFactory, SQSFactory
 from constructs import Construct
 
 
-class SqsToLambdaStage(Stage):
+class SqsToLambdaStage(DataStage):
     """
     Class that represents an SQS to Lambda Transform DDK Stage.
     """

--- a/core/tests/unit/test_basic_data_pipeline.py
+++ b/core/tests/unit/test_basic_data_pipeline.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from aws_cdk.assertions import Template
 from aws_cdk.aws_lambda import Code
 from aws_ddk_core.base import BaseStack
-from aws_ddk_core.pipelines import Pipeline
+from aws_ddk_core.pipelines import DataPipeline
 from aws_ddk_core.resources import S3Factory
 from aws_ddk_core.stages import S3EventStage, SqsToLambdaStage
 
@@ -45,7 +45,7 @@ def test_basic_pipeline(test_stack: BaseStack) -> None:
     )
     bucket.grant_read_write(sqs_lambda_stage.function)
 
-    Pipeline(scope=test_stack, id="dummy-pipeline").add_stage(s3_event_stage).add_stage(sqs_lambda_stage)
+    DataPipeline(scope=test_stack, id="dummy-pipeline").add_stage(s3_event_stage).add_stage(sqs_lambda_stage)
 
     template = Template.from_stack(test_stack)
     template.has_resource_properties(


### PR DESCRIPTION
### Refactoring
- Refactoring: Rename DDK Stage and Pipeline classes to DataStage and DataPipeline

### Detail
- Renames DDK `Stage` and `Pipeline` classes to `DataStage` and `DataPipeline`

### Relates
- https://github.com/awslabs/aws-ddk/issues/32

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
