### PR TITLE
(core): cicd pipeline alerting

### DIFF
--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -19,7 +19,7 @@ from aws_cdk import Environment, Stage
 from aws_cdk.aws_codestarnotifications import DetailType, NotificationRule
 from aws_cdk.aws_iam import PolicyStatement, ServicePrincipal
 from aws_cdk.aws_kms import Key
-from aws_cdk.aws_sns import Topic
+from aws_cdk.aws_sns import ITopic, Topic
 from aws_cdk.pipelines import CodeBuildStep, CodePipeline, CodePipelineSource, IFileSetProducer, ManualApprovalStep
 from aws_ddk_core.base import BaseStack
 from aws_ddk_core.cicd import (
@@ -361,20 +361,6 @@ class CICDPipelineStack(BaseStack):
                         self, f"{self.pipeline_name}-cicd-notifications-key", alias_name="alias/aws/sns"
                     ),
                 )
-                # ).add_to_resource_policy(
-                #     PolicyStatement(
-                #         principals=[
-                #             ServicePrincipal("codestar-notifications.amazonaws.com")
-                #         ],
-                #         actions=["SNS:Publish"],
-                #         resources=["*"],
-                #         conditions= {
-                #             "StringEquals": {
-                #                 "aws:SourceAccount": self.account
-                #             }
-                #         }
-                #     )
-                # )
             ],
         )
         return self

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -357,10 +357,12 @@ class CICDPipelineStack(BaseStack):
                 if self._config.get_env_config(self.environment_id).get("notifications_topic_arn")
                 else Topic(
                     self,
-                    f"{self.pipeline_name}-cicd-notifications",
-                    topic_name=f"{self.pipeline_name}-cicd-notifications",
+                    f"{self.pipeline_name}-{self.environment_id}-notifications",
+                    topic_name=f"{self.pipeline_name}-{self.environment_id}-notifications",
                     master_key=Key.from_lookup(
-                        self, f"{self.pipeline_name}-cicd-notifications-key", alias_name="alias/aws/sns"
+                        self,
+                        f"{self.pipeline_name}-{self.environment_id}-notifications-key",
+                        alias_name="alias/aws/sns",
                     ),
                 )
             ],

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -17,9 +17,9 @@ from typing import Any, Dict, List, Optional
 
 from aws_cdk import Environment, Stage
 from aws_cdk.aws_codestarnotifications import DetailType, NotificationRule
-from aws_cdk.aws_iam import PolicyStatement, ServicePrincipal
+from aws_cdk.aws_iam import PolicyStatement
 from aws_cdk.aws_kms import Key
-from aws_cdk.aws_sns import ITopic, Topic
+from aws_cdk.aws_sns import Topic
 from aws_cdk.pipelines import CodeBuildStep, CodePipeline, CodePipelineSource, IFileSetProducer, ManualApprovalStep
 from aws_ddk_core.base import BaseStack
 from aws_ddk_core.cicd import (

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -350,7 +350,9 @@ class CICDPipelineStack(BaseStack):
             source=self._pipeline.pipeline,
             targets=[
                 Topic.from_topic_arn(
-                    self, "topic", topic_arn=self._config.get_env_config(self.environment_id).get("notifications_topic_arn")
+                    self,
+                    "topic",
+                    topic_arn=self._config.get_env_config(self.environment_id).get("notifications_topic_arn"),
                 )
                 if self._config.get_env_config(self.environment_id).get("notifications_topic_arn")
                 else Topic(

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -350,9 +350,9 @@ class CICDPipelineStack(BaseStack):
             source=self._pipeline.pipeline,
             targets=[
                 Topic.from_topic_arn(
-                    self, "topic", topic_arn=self._config.get_env_config("cicd").get("notifications_topic_arn")
+                    self, "topic", topic_arn=self._config.get_env_config(self.environment_id).get("notifications_topic_arn")
                 )
-                if self._config.get_env_config("cicd").get("notifications_topic_arn")
+                if self._config.get_env_config(self.environment_id).get("notifications_topic_arn")
                 else Topic(
                     self,
                     f"{self.pipeline_name}-cicd-notifications",

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -17,15 +17,10 @@ from typing import Any, Dict, List, Optional
 
 from aws_cdk import Environment, Stage
 from aws_cdk.aws_iam import PolicyStatement
-<<<<<<< HEAD
-from aws_cdk.pipelines import CodeBuildStep, CodePipeline, CodePipelineSource, ManualApprovalStep
 from aws_cdk.aws_codestarnotifications import DetailType, NotificationRule
 from aws_ddk_core.base import BaseStack
-from aws_ddk_core.cicd import get_code_commit_source_action, get_synth_action
 from aws_cdk.aws_sns import Topic
-=======
 from aws_cdk.pipelines import CodeBuildStep, CodePipeline, CodePipelineSource, IFileSetProducer, ManualApprovalStep
-from aws_ddk_core.base import BaseStack
 from aws_ddk_core.cicd import (
     get_bandit_action,
     get_cfn_nag_action,
@@ -33,7 +28,6 @@ from aws_ddk_core.cicd import (
     get_synth_action,
     get_tests_action,
 )
->>>>>>> d34bd1d98f5a170026a1b65f9629e909ca839930
 from aws_ddk_core.config import Config
 from constructs import Construct
 from marshmallow import Schema, fields

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -15,7 +15,6 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-import aws_cdk.aws_codebuild as codebuild
 from aws_cdk import Environment, Stage
 from aws_cdk.aws_codestarnotifications import DetailType, NotificationRule
 from aws_cdk.aws_iam import PolicyStatement, ServicePrincipal

--- a/core/tests/unit/test_cicd_pipeline_stack.py
+++ b/core/tests/unit/test_cicd_pipeline_stack.py
@@ -50,7 +50,6 @@ def test_cicd_pipeline_simple(cdk_app: App) -> None:
         .add_synth_action()
         .build()
         .add_stage("dev", DevStage(cdk_app, "dev"))
-        .add_notifications()
         .synth()
     )
     template = Template.from_stack(pipeline_stack)
@@ -237,9 +236,10 @@ def test_cicd_pipeline_full(cdk_app: App) -> None:
         .add_test_stage()
         .add_stage("dev", DevStage(cdk_app, "dev"))
         .synth()
+        .add_notifications()
     )
     template = Template.from_stack(pipeline_stack)
-    # Check if synthesized pipeline contains source, synth, self-update, and app stage
+    # Check if synthesized pipeline contains source, synth, self-update, security-lint and app stages
     template.has_resource_properties(
         "AWS::CodePipeline::Pipeline",
         props={
@@ -418,6 +418,14 @@ def test_cicd_pipeline_full(cdk_app: App) -> None:
                     ],
                 }
             ),
+        },
+    )
+    # Check if SNS Topic for notifications exists
+    template.has_resource_properties(
+        "AWS::SNS::Topic",
+        props={
+            "TopicName": Match.exact(pattern="dummy-pipeline-cicd-notifications"),
+            "KmsMasterKeyId": Match.any_value(),
         },
     )
     template.has_resource_properties(

--- a/core/tests/unit/test_cicd_pipeline_stack.py
+++ b/core/tests/unit/test_cicd_pipeline_stack.py
@@ -50,6 +50,7 @@ def test_cicd_pipeline_simple(cdk_app: App) -> None:
         .add_synth_action()
         .build()
         .add_stage("dev", DevStage(cdk_app, "dev"))
+        .add_notifications()
         .synth()
     )
     template = Template.from_stack(pipeline_stack)

--- a/core/tests/unit/test_cicd_pipeline_stack.py
+++ b/core/tests/unit/test_cicd_pipeline_stack.py
@@ -428,6 +428,25 @@ def test_cicd_pipeline_full(cdk_app: App) -> None:
             "KmsMasterKeyId": Match.any_value(),
         },
     )
+    # Check if SNS Topic policy is in place
+    template.has_resource_properties(
+        "AWS::SNS::TopicPolicy",
+        props={
+            "PolicyDocument": Match.object_like(
+                pattern={
+                    "Statement": [
+                        {
+                            "Action": "sns:Publish",
+                            "Effect": "Allow",
+                            "Principal": {"Service": "codestar-notifications.amazonaws.com"},
+                            "Resource": {"Ref": "dummypipelinecicdnotifications4ADAB795"},
+                            "Sid": "0",
+                        },
+                    ],
+                }
+            )
+        },
+    )
     template.has_resource_properties(
         "AWS::IAM::Role",
         props={

--- a/core/tests/unit/test_cicd_pipeline_stack.py
+++ b/core/tests/unit/test_cicd_pipeline_stack.py
@@ -221,7 +221,7 @@ def test_cicd_pipeline_simple(cdk_app: App) -> None:
     )
 
 
-def test_cicd_pipeline_full(cdk_app: App) -> None:
+def test_cicd_pipeline_notifications(cdk_app: App) -> None:
     pipeline_stack = (
         CICDPipelineStack(
             cdk_app,
@@ -232,194 +232,12 @@ def test_cicd_pipeline_full(cdk_app: App) -> None:
         .add_source_action(repository_name="dummy-repository")
         .add_synth_action()
         .build()
-        .add_security_lint_stage()
-        .add_test_stage()
         .add_stage("dev", DevStage(cdk_app, "dev"))
         .synth()
         .add_notifications()
     )
     template = Template.from_stack(pipeline_stack)
-    # Check if synthesized pipeline contains source, synth, self-update, security-lint and app stages
-    template.has_resource_properties(
-        "AWS::CodePipeline::Pipeline",
-        props={
-            "Stages": Match.array_with(
-                pattern=[
-                    Match.object_like(
-                        pattern={
-                            "Name": "Source",
-                            "Actions": Match.array_with(
-                                pattern=[
-                                    Match.object_like(
-                                        pattern={
-                                            "Name": "dummy-repository",
-                                            "ActionTypeId": {
-                                                "Category": "Source",
-                                                "Provider": "CodeCommit",
-                                            },
-                                            "Configuration": {
-                                                "RepositoryName": "dummy-repository",
-                                                "BranchName": "main",
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
-                        },
-                    ),
-                    Match.object_like(
-                        pattern={
-                            "Name": "Build",
-                            "Actions": Match.array_with(
-                                pattern=[
-                                    Match.object_like(
-                                        pattern={
-                                            "Name": "Synth",
-                                            "ActionTypeId": {
-                                                "Category": "Build",
-                                                "Provider": "CodeBuild",
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
-                        },
-                    ),
-                    Match.object_like(
-                        pattern={
-                            "Name": "UpdatePipeline",
-                            "Actions": Match.array_with(
-                                pattern=[
-                                    Match.object_like(
-                                        pattern={
-                                            "Name": "SelfMutate",
-                                            "ActionTypeId": {
-                                                "Category": "Build",
-                                                "Provider": "CodeBuild",
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
-                        },
-                    ),
-                    Match.object_like(
-                        pattern={
-                            "Name": "SecurityLint",
-                            "Actions": Match.array_with(
-                                pattern=[
-                                    Match.object_like(
-                                        pattern={
-                                            "Name": "Bandit",
-                                            "ActionTypeId": {
-                                                "Category": "Build",
-                                                "Provider": "CodeBuild",
-                                            },
-                                        },
-                                    ),
-                                    Match.object_like(
-                                        pattern={
-                                            "Name": "CFNNag",
-                                            "ActionTypeId": {
-                                                "Category": "Build",
-                                                "Provider": "CodeBuild",
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
-                        },
-                    ),
-                    Match.object_like(
-                        pattern={
-                            "Name": "Tests",
-                            "Actions": Match.array_with(
-                                pattern=[
-                                    Match.object_like(
-                                        pattern={
-                                            "Name": "Tests",
-                                            "ActionTypeId": {
-                                                "Category": "Build",
-                                                "Provider": "CodeBuild",
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
-                        },
-                    ),
-                    Match.object_like(
-                        pattern={
-                            "Name": "dev",
-                        },
-                    ),
-                ],
-            ),
-        },
-    )
-    # Check if pipeline bucket is KMS-encrypted and blocks public access
-    template.has_resource_properties(
-        "AWS::S3::Bucket",
-        props={
-            "PublicAccessBlockConfiguration": {
-                "BlockPublicAcls": True,
-                "BlockPublicPolicy": True,
-                "IgnorePublicAcls": True,
-                "RestrictPublicBuckets": True,
-            },
-            "BucketEncryption": {
-                "ServerSideEncryptionConfiguration": Match.array_with(
-                    pattern=[
-                        Match.object_like(
-                            pattern={
-                                "ServerSideEncryptionByDefault": {
-                                    "SSEAlgorithm": "aws:kms",
-                                },
-                            },
-                        ),
-                    ],
-                ),
-            },
-        },
-    )
-    # Check if KMS keys are rotated
-    template.has_resource_properties(
-        "AWS::KMS::Key",
-        props={
-            "EnableKeyRotation": True,
-        },
-    )
-    # Check if all IAM roles have permissions boundary attached
-    template.has_resource_properties(
-        "AWS::IAM::Role",
-        props={
-            "AssumeRolePolicyDocument": Match.object_like(
-                pattern={
-                    "Statement": [
-                        {
-                            "Action": "sts:AssumeRole",
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": "codepipeline.amazonaws.com",
-                            },
-                        },
-                    ],
-                },
-            ),
-            "PermissionsBoundary": Match.object_like(
-                pattern={
-                    "Fn::Join": [
-                        "",
-                        [
-                            "arn:",
-                            {"Ref": "AWS::Partition"},
-                            ":iam::111111111111:policy/ddk-dev-hnb659fds-permissions-boundary-111111111111-us-east-1",  # noqa
-                        ],
-                    ],
-                }
-            ),
-        },
-    )
+
     # Check if SNS Topic for notifications exists
     template.has_resource_properties(
         "AWS::SNS::Topic",
@@ -445,35 +263,5 @@ def test_cicd_pipeline_full(cdk_app: App) -> None:
                     ],
                 }
             )
-        },
-    )
-    template.has_resource_properties(
-        "AWS::IAM::Role",
-        props={
-            "AssumeRolePolicyDocument": Match.object_like(
-                pattern={
-                    "Statement": [
-                        {
-                            "Action": "sts:AssumeRole",
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": "codebuild.amazonaws.com",
-                            },
-                        },
-                    ],
-                },
-            ),
-            "PermissionsBoundary": Match.object_like(
-                pattern={
-                    "Fn::Join": [
-                        "",
-                        [
-                            "arn:",
-                            {"Ref": "AWS::Partition"},
-                            ":iam::111111111111:policy/ddk-dev-hnb659fds-permissions-boundary-111111111111-us-east-1",  # noqa
-                        ],
-                    ],
-                }
-            ),
         },
     )


### PR DESCRIPTION
### Feature 
- Adding method `add_notifications()` to `aws_ddk_core.cicd.pipeline` 


### Detail
 - Adds event rule for failed pipeline events
  - Adds sns topic for notifications if not specified in config
  - Adds method to full test [tests/unit/test_cicd_pipeline_stack.py::test_cicd_pipeline_full](./core/tests/unit/test_cicd_pipeline_stack.py::test_cicd_pipeline_full)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
