### PR TITLE
Add type checking for boto3

### DIFF
--- a/.github/workflows/static-checking.yml
+++ b/.github/workflows/static-checking.yml
@@ -28,15 +28,14 @@ jobs:
           python -m pip install poetry
           poetry config virtualenvs.create false --local
           poetry install -vvv
-      - name: mypy check
-        run: |
-          mypy --install-types --non-interactive core
-          mypy --install-types --non-interactive cli
-      - name: Flake8 Lint
-        run: flake8 .
-      - name: Black style
-        run: black --check .
       - name: Imports order check (isort)
         run: isort --check .
+      - name: Black style
+        run: black --check .
+      - name: mypy check
+        run: |
+          mypy --install-types --non-interactive cli core
+      - name: Flake8 Lint
+        run: flake8 .
       - name: Documentation check
         run: doc8 --ignore D005,D002 --max-line-length 120 docs/source

--- a/cli/aws_ddk/services/cfn.py
+++ b/cli/aws_ddk/services/cfn.py
@@ -15,7 +15,7 @@
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import botocore.exceptions
 from aws_ddk.utils import boto3_client
@@ -28,7 +28,7 @@ CHANGESET_PREFIX = "aws-ddk-cli-deploy-"
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def get_stack_status(stack_name: str) -> str:
+def get_stack_status(stack_name: str) -> Any:
     client = boto3_client("cloudformation")
     try:
         resp = client.describe_stacks(StackName=stack_name)

--- a/cli/aws_ddk/services/cfn.py
+++ b/cli/aws_ddk/services/cfn.py
@@ -15,10 +15,15 @@
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import botocore.exceptions
 from aws_ddk.utils import boto3_client
+
+if TYPE_CHECKING:
+    from mypy_boto3_cloudformation.waiter import StackCreateCompleteWaiter
+    from mypy_boto3_cloudformation.waiter import StackUpdateCompleteWaiter
+    from mypy_boto3_cloudformation.type_defs import WaiterConfigTypeDef
 
 CHANGESET_PREFIX = "aws-ddk-cli-deploy-"
 
@@ -33,7 +38,7 @@ def get_stack_status(stack_name: str) -> str:
             raise ValueError(f"CloudFormation stack {stack_name} not found.")
     except botocore.exceptions.ClientError:
         raise
-    return cast(str, resp["Stacks"][0]["StackStatus"])
+    return resp["Stacks"][0]["StackStatus"]
 
 
 def does_stack_exist(stack_name: str) -> bool:
@@ -43,7 +48,7 @@ def does_stack_exist(stack_name: str) -> bool:
         if len(resp["Stacks"]) < 1:
             return False
     except botocore.exceptions.ClientError as ex:
-        error: Dict[str, Any] = ex.response["Error"]
+        error = ex.response["Error"]
         if error["Code"] == "ValidationError" and f"Stack with id {stack_name} does not exist" in error["Message"]:
             return False
         raise
@@ -52,7 +57,7 @@ def does_stack_exist(stack_name: str) -> bool:
 
 def _wait_for_changeset(changeset_id: str, stack_name: str) -> bool:
     waiter = boto3_client("cloudformation").get_waiter("change_set_create_complete")
-    waiter_config = {"Delay": 1}
+    waiter_config: "WaiterConfigTypeDef" = {"Delay": 1}
     try:
         waiter.wait(ChangeSetName=changeset_id, StackName=stack_name, WaiterConfig=waiter_config)
     except botocore.exceptions.WaiterError as ex:
@@ -101,13 +106,14 @@ def _execute_changeset(changeset_id: str, stack_name: str) -> None:
 
 
 def _wait_for_execute(stack_name: str, changeset_type: str) -> None:
+    waiter: "Union[StackCreateCompleteWaiter, StackUpdateCompleteWaiter]"
     if changeset_type == "CREATE":
         waiter = boto3_client("cloudformation").get_waiter("stack_create_complete")
     elif changeset_type == "UPDATE":
         waiter = boto3_client("cloudformation").get_waiter("stack_update_complete")
     else:
         raise RuntimeError(f"Invalid changeset type {changeset_type}")
-    waiter_config = {
+    waiter_config: "WaiterConfigTypeDef" = {
         "Delay": 5,
         "MaxAttempts": 480,
     }

--- a/cli/aws_ddk/services/cfn.py
+++ b/cli/aws_ddk/services/cfn.py
@@ -28,7 +28,7 @@ CHANGESET_PREFIX = "aws-ddk-cli-deploy-"
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def get_stack_status(stack_name: str) -> Any:
+def get_stack_status(stack_name: str) -> str:
     client = boto3_client("cloudformation")
     try:
         resp = client.describe_stacks(StackName=stack_name)

--- a/cli/aws_ddk/services/codecommit.py
+++ b/cli/aws_ddk/services/codecommit.py
@@ -24,17 +24,14 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 def create_repository(name: str, description: Optional[str], tags: Optional[Dict[str, str]]) -> str:
     client = boto3_client("codecommit")
-    args: Dict[str, Union[str, Dict[str, str]]] = {
-        "repositoryName": name,
-    }
-    if description:
-        args.update({"repositoryDescription": description})
-    if tags:
-        args.update({"tags": tags})
     try:
-        resp: Dict[str, Dict[str, str]] = client.create_repository(**args)
+        resp = client.create_repository(
+            repositoryName=name,
+            repositoryDescription=description or "",
+            tags=tags or {},
+        )
     except botocore.exceptions.ClientError as ex:
-        error: Dict[str, Any] = ex.response["Error"]
+        error = ex.response["Error"]
         if error["Code"] == "RepositoryNameExistsException":
             echo(f"Repository {name} already exists in the AWS account.")
             resp = client.get_repository(repositoryName=name)

--- a/cli/aws_ddk/services/codecommit.py
+++ b/cli/aws_ddk/services/codecommit.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 import botocore.exceptions
 from aws_ddk.utils import boto3_client

--- a/cli/aws_ddk/services/codecommit.py
+++ b/cli/aws_ddk/services/codecommit.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 import botocore.exceptions
 from aws_ddk.utils import boto3_client
@@ -22,7 +22,7 @@ from click import echo
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def create_repository(name: str, description: Optional[str], tags: Optional[Dict[str, str]]) -> str:
+def create_repository(name: str, description: Optional[str], tags: Optional[Dict[str, str]]) -> Any:
     client = boto3_client("codecommit")
     try:
         resp = client.create_repository(

--- a/cli/aws_ddk/services/codecommit.py
+++ b/cli/aws_ddk/services/codecommit.py
@@ -22,7 +22,7 @@ from click import echo
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def create_repository(name: str, description: Optional[str], tags: Optional[Dict[str, str]]) -> Any:
+def create_repository(name: str, description: Optional[str], tags: Optional[Dict[str, str]]) -> str:
     client = boto3_client("codecommit")
     try:
         resp = client.create_repository(

--- a/cli/aws_ddk/utils.py
+++ b/cli/aws_ddk/utils.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import os
+from typing import TYPE_CHECKING, overload
 
 import boto3
-import botocore.exceptions
+from botocore.config import Config
+
 from aws_ddk.__metadata__ import __version__
-from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
     from typing_extensions import Literal
@@ -31,8 +32,8 @@ if TYPE_CHECKING:
 
 
 
-def get_botocore_config() -> botocore.config.Config:
-    return botocore.config.Config(
+def get_botocore_config() -> Config:
+    return Config(
         retries={"max_attempts": 5},
         connect_timeout=10,
         max_pool_connections=10,

--- a/cli/aws_ddk/utils.py
+++ b/cli/aws_ddk/utils.py
@@ -17,6 +17,18 @@ import os
 import boto3
 import botocore.exceptions
 from aws_ddk.__metadata__ import __version__
+from typing import TYPE_CHECKING, overload
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
+    from mypy_boto3_codecommit.literals import ServiceName
+    from mypy_boto3_codecommit.client import CodeCommitClient
+    from mypy_boto3_cloudformation.client import CloudFormationClient
+    from boto3.resources.base import ServiceResource
+    from mypy_boto3_sts.client import STSClient
+    from botocore.client import BaseClient
+
+
 
 
 def get_botocore_config() -> botocore.config.Config:
@@ -27,12 +39,19 @@ def get_botocore_config() -> botocore.config.Config:
         user_agent_extra=f"awsddk/{__version__}",
     )
 
+@overload
+def boto3_client(service_name: 'Literal["sts"]') -> "STSClient": ...
+@overload
+def boto3_client(service_name: 'Literal["cloudformation"]') -> "CloudFormationClient": ...
+@overload
+def boto3_client(service_name: 'Literal["codecommit"]') -> "CodeCommitClient": ...
 
-def boto3_client(service_name: str) -> boto3.client:
+
+def boto3_client(service_name: "ServiceName") -> "BaseClient":
     return boto3.client(service_name=service_name, use_ssl=True, config=get_botocore_config())
 
 
-def boto3_resource(service_name: str) -> boto3.client:
+def boto3_resource(service_name: "ServiceName") -> "ServiceResource":
     return boto3.resource(service_name=service_name, use_ssl=True, config=get_botocore_config())
 
 

--- a/cli/aws_ddk/utils.py
+++ b/cli/aws_ddk/utils.py
@@ -16,20 +16,17 @@ import os
 from typing import TYPE_CHECKING, overload
 
 import boto3
+from aws_ddk.__metadata__ import __version__
 from botocore.config import Config
 
-from aws_ddk.__metadata__ import __version__
-
 if TYPE_CHECKING:
-    from typing_extensions import Literal
-    from mypy_boto3_codecommit.literals import ServiceName
-    from mypy_boto3_codecommit.client import CodeCommitClient
-    from mypy_boto3_cloudformation.client import CloudFormationClient
     from boto3.resources.base import ServiceResource
-    from mypy_boto3_sts.client import STSClient
     from botocore.client import BaseClient
-
-
+    from mypy_boto3_cloudformation.client import CloudFormationClient
+    from mypy_boto3_codecommit.client import CodeCommitClient
+    from mypy_boto3_codecommit.literals import ServiceName
+    from mypy_boto3_sts.client import STSClient
+    from typing_extensions import Literal
 
 
 def get_botocore_config() -> Config:
@@ -40,12 +37,20 @@ def get_botocore_config() -> Config:
         user_agent_extra=f"awsddk/{__version__}",
     )
 
+
 @overload
-def boto3_client(service_name: 'Literal["sts"]') -> "STSClient": ...
+def boto3_client(service_name: 'Literal["sts"]') -> "STSClient":
+    ...
+
+
 @overload
-def boto3_client(service_name: 'Literal["cloudformation"]') -> "CloudFormationClient": ...
+def boto3_client(service_name: 'Literal["cloudformation"]') -> "CloudFormationClient":
+    ...
+
+
 @overload
-def boto3_client(service_name: 'Literal["codecommit"]') -> "CodeCommitClient": ...
+def boto3_client(service_name: 'Literal["codecommit"]') -> "CodeCommitClient":
+    ...
 
 
 def boto3_client(service_name: "ServiceName") -> "BaseClient":

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -45,14 +45,14 @@ chardet = ">=3.0.2"
 
 [[package]]
 name = "boto3"
-version = "1.21.13"
+version = "1.21.14"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.24.13,<1.25.0"
+botocore = ">=1.24.14,<1.25.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -60,327 +60,8 @@ s3transfer = ">=0.5.0,<0.6.0"
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
-name = "boto3-stubs-lite"
-version = "1.21.13"
-description = "Type annotations for boto3 1.21.13 generated with mypy-boto3-builder 7.3.0"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-botocore-stubs = "*"
-mypy-boto3-cloudformation = {version = ">=1.21.0", optional = true, markers = "extra == \"cloudformation\""}
-mypy-boto3-codecommit = {version = ">=1.21.0", optional = true, markers = "extra == \"codecommit\""}
-mypy-boto3-sts = {version = ">=1.21.0", optional = true, markers = "extra == \"sts\""}
-typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
-
-[package.extras]
-accessanalyzer = ["mypy-boto3-accessanalyzer (>=1.21.0)"]
-account = ["mypy-boto3-account (>=1.21.0)"]
-acm = ["mypy-boto3-acm (>=1.21.0)"]
-acm-pca = ["mypy-boto3-acm-pca (>=1.21.0)"]
-alexaforbusiness = ["mypy-boto3-alexaforbusiness (>=1.21.0)"]
-all = ["mypy-boto3-accessanalyzer (>=1.21.0)", "mypy-boto3-account (>=1.21.0)", "mypy-boto3-acm (>=1.21.0)", "mypy-boto3-acm-pca (>=1.21.0)", "mypy-boto3-alexaforbusiness (>=1.21.0)", "mypy-boto3-amp (>=1.21.0)", "mypy-boto3-amplify (>=1.21.0)", "mypy-boto3-amplifybackend (>=1.21.0)", "mypy-boto3-amplifyuibuilder (>=1.21.0)", "mypy-boto3-apigateway (>=1.21.0)", "mypy-boto3-apigatewaymanagementapi (>=1.21.0)", "mypy-boto3-apigatewayv2 (>=1.21.0)", "mypy-boto3-appconfig (>=1.21.0)", "mypy-boto3-appconfigdata (>=1.21.0)", "mypy-boto3-appflow (>=1.21.0)", "mypy-boto3-appintegrations (>=1.21.0)", "mypy-boto3-application-autoscaling (>=1.21.0)", "mypy-boto3-application-insights (>=1.21.0)", "mypy-boto3-applicationcostprofiler (>=1.21.0)", "mypy-boto3-appmesh (>=1.21.0)", "mypy-boto3-apprunner (>=1.21.0)", "mypy-boto3-appstream (>=1.21.0)", "mypy-boto3-appsync (>=1.21.0)", "mypy-boto3-athena (>=1.21.0)", "mypy-boto3-auditmanager (>=1.21.0)", "mypy-boto3-autoscaling (>=1.21.0)", "mypy-boto3-autoscaling-plans (>=1.21.0)", "mypy-boto3-backup (>=1.21.0)", "mypy-boto3-backup-gateway (>=1.21.0)", "mypy-boto3-batch (>=1.21.0)", "mypy-boto3-braket (>=1.21.0)", "mypy-boto3-budgets (>=1.21.0)", "mypy-boto3-ce (>=1.21.0)", "mypy-boto3-chime (>=1.21.0)", "mypy-boto3-chime-sdk-identity (>=1.21.0)", "mypy-boto3-chime-sdk-meetings (>=1.21.0)", "mypy-boto3-chime-sdk-messaging (>=1.21.0)", "mypy-boto3-cloud9 (>=1.21.0)", "mypy-boto3-cloudcontrol (>=1.21.0)", "mypy-boto3-clouddirectory (>=1.21.0)", "mypy-boto3-cloudformation (>=1.21.0)", "mypy-boto3-cloudfront (>=1.21.0)", "mypy-boto3-cloudhsm (>=1.21.0)", "mypy-boto3-cloudhsmv2 (>=1.21.0)", "mypy-boto3-cloudsearch (>=1.21.0)", "mypy-boto3-cloudsearchdomain (>=1.21.0)", "mypy-boto3-cloudtrail (>=1.21.0)", "mypy-boto3-cloudwatch (>=1.21.0)", "mypy-boto3-codeartifact (>=1.21.0)", "mypy-boto3-codebuild (>=1.21.0)", "mypy-boto3-codecommit (>=1.21.0)", "mypy-boto3-codedeploy (>=1.21.0)", "mypy-boto3-codeguru-reviewer (>=1.21.0)", "mypy-boto3-codeguruprofiler (>=1.21.0)", "mypy-boto3-codepipeline (>=1.21.0)", "mypy-boto3-codestar (>=1.21.0)", "mypy-boto3-codestar-connections (>=1.21.0)", "mypy-boto3-codestar-notifications (>=1.21.0)", "mypy-boto3-cognito-identity (>=1.21.0)", "mypy-boto3-cognito-idp (>=1.21.0)", "mypy-boto3-cognito-sync (>=1.21.0)", "mypy-boto3-comprehend (>=1.21.0)", "mypy-boto3-comprehendmedical (>=1.21.0)", "mypy-boto3-compute-optimizer (>=1.21.0)", "mypy-boto3-config (>=1.21.0)", "mypy-boto3-connect (>=1.21.0)", "mypy-boto3-connect-contact-lens (>=1.21.0)", "mypy-boto3-connectparticipant (>=1.21.0)", "mypy-boto3-cur (>=1.21.0)", "mypy-boto3-customer-profiles (>=1.21.0)", "mypy-boto3-databrew (>=1.21.0)", "mypy-boto3-dataexchange (>=1.21.0)", "mypy-boto3-datapipeline (>=1.21.0)", "mypy-boto3-datasync (>=1.21.0)", "mypy-boto3-dax (>=1.21.0)", "mypy-boto3-detective (>=1.21.0)", "mypy-boto3-devicefarm (>=1.21.0)", "mypy-boto3-devops-guru (>=1.21.0)", "mypy-boto3-directconnect (>=1.21.0)", "mypy-boto3-discovery (>=1.21.0)", "mypy-boto3-dlm (>=1.21.0)", "mypy-boto3-dms (>=1.21.0)", "mypy-boto3-docdb (>=1.21.0)", "mypy-boto3-drs (>=1.21.0)", "mypy-boto3-ds (>=1.21.0)", "mypy-boto3-dynamodb (>=1.21.0)", "mypy-boto3-dynamodbstreams (>=1.21.0)", "mypy-boto3-ebs (>=1.21.0)", "mypy-boto3-ec2 (>=1.21.0)", "mypy-boto3-ec2-instance-connect (>=1.21.0)", "mypy-boto3-ecr (>=1.21.0)", "mypy-boto3-ecr-public (>=1.21.0)", "mypy-boto3-ecs (>=1.21.0)", "mypy-boto3-efs (>=1.21.0)", "mypy-boto3-eks (>=1.21.0)", "mypy-boto3-elastic-inference (>=1.21.0)", "mypy-boto3-elasticache (>=1.21.0)", "mypy-boto3-elasticbeanstalk (>=1.21.0)", "mypy-boto3-elastictranscoder (>=1.21.0)", "mypy-boto3-elb (>=1.21.0)", "mypy-boto3-elbv2 (>=1.21.0)", "mypy-boto3-emr (>=1.21.0)", "mypy-boto3-emr-containers (>=1.21.0)", "mypy-boto3-es (>=1.21.0)", "mypy-boto3-events (>=1.21.0)", "mypy-boto3-evidently (>=1.21.0)", "mypy-boto3-finspace (>=1.21.0)", "mypy-boto3-finspace-data (>=1.21.0)", "mypy-boto3-firehose (>=1.21.0)", "mypy-boto3-fis (>=1.21.0)", "mypy-boto3-fms (>=1.21.0)", "mypy-boto3-forecast (>=1.21.0)", "mypy-boto3-forecastquery (>=1.21.0)", "mypy-boto3-frauddetector (>=1.21.0)", "mypy-boto3-fsx (>=1.21.0)", "mypy-boto3-gamelift (>=1.21.0)", "mypy-boto3-glacier (>=1.21.0)", "mypy-boto3-globalaccelerator (>=1.21.0)", "mypy-boto3-glue (>=1.21.0)", "mypy-boto3-grafana (>=1.21.0)", "mypy-boto3-greengrass (>=1.21.0)", "mypy-boto3-greengrassv2 (>=1.21.0)", "mypy-boto3-groundstation (>=1.21.0)", "mypy-boto3-guardduty (>=1.21.0)", "mypy-boto3-health (>=1.21.0)", "mypy-boto3-healthlake (>=1.21.0)", "mypy-boto3-honeycode (>=1.21.0)", "mypy-boto3-iam (>=1.21.0)", "mypy-boto3-identitystore (>=1.21.0)", "mypy-boto3-imagebuilder (>=1.21.0)", "mypy-boto3-importexport (>=1.21.0)", "mypy-boto3-inspector (>=1.21.0)", "mypy-boto3-inspector2 (>=1.21.0)", "mypy-boto3-iot (>=1.21.0)", "mypy-boto3-iot-data (>=1.21.0)", "mypy-boto3-iot-jobs-data (>=1.21.0)", "mypy-boto3-iot1click-devices (>=1.21.0)", "mypy-boto3-iot1click-projects (>=1.21.0)", "mypy-boto3-iotanalytics (>=1.21.0)", "mypy-boto3-iotdeviceadvisor (>=1.21.0)", "mypy-boto3-iotevents (>=1.21.0)", "mypy-boto3-iotevents-data (>=1.21.0)", "mypy-boto3-iotfleethub (>=1.21.0)", "mypy-boto3-iotsecuretunneling (>=1.21.0)", "mypy-boto3-iotsitewise (>=1.21.0)", "mypy-boto3-iotthingsgraph (>=1.21.0)", "mypy-boto3-iottwinmaker (>=1.21.0)", "mypy-boto3-iotwireless (>=1.21.0)", "mypy-boto3-ivs (>=1.21.0)", "mypy-boto3-kafka (>=1.21.0)", "mypy-boto3-kafkaconnect (>=1.21.0)", "mypy-boto3-kendra (>=1.21.0)", "mypy-boto3-keyspaces (>=1.21.0)", "mypy-boto3-kinesis (>=1.21.0)", "mypy-boto3-kinesis-video-archived-media (>=1.21.0)", "mypy-boto3-kinesis-video-media (>=1.21.0)", "mypy-boto3-kinesis-video-signaling (>=1.21.0)", "mypy-boto3-kinesisanalytics (>=1.21.0)", "mypy-boto3-kinesisanalyticsv2 (>=1.21.0)", "mypy-boto3-kinesisvideo (>=1.21.0)", "mypy-boto3-kms (>=1.21.0)", "mypy-boto3-lakeformation (>=1.21.0)", "mypy-boto3-lambda (>=1.21.0)", "mypy-boto3-lex-models (>=1.21.0)", "mypy-boto3-lex-runtime (>=1.21.0)", "mypy-boto3-lexv2-models (>=1.21.0)", "mypy-boto3-lexv2-runtime (>=1.21.0)", "mypy-boto3-license-manager (>=1.21.0)", "mypy-boto3-lightsail (>=1.21.0)", "mypy-boto3-location (>=1.21.0)", "mypy-boto3-logs (>=1.21.0)", "mypy-boto3-lookoutequipment (>=1.21.0)", "mypy-boto3-lookoutmetrics (>=1.21.0)", "mypy-boto3-lookoutvision (>=1.21.0)", "mypy-boto3-machinelearning (>=1.21.0)", "mypy-boto3-macie (>=1.21.0)", "mypy-boto3-macie2 (>=1.21.0)", "mypy-boto3-managedblockchain (>=1.21.0)", "mypy-boto3-marketplace-catalog (>=1.21.0)", "mypy-boto3-marketplace-entitlement (>=1.21.0)", "mypy-boto3-marketplacecommerceanalytics (>=1.21.0)", "mypy-boto3-mediaconnect (>=1.21.0)", "mypy-boto3-mediaconvert (>=1.21.0)", "mypy-boto3-medialive (>=1.21.0)", "mypy-boto3-mediapackage (>=1.21.0)", "mypy-boto3-mediapackage-vod (>=1.21.0)", "mypy-boto3-mediastore (>=1.21.0)", "mypy-boto3-mediastore-data (>=1.21.0)", "mypy-boto3-mediatailor (>=1.21.0)", "mypy-boto3-memorydb (>=1.21.0)", "mypy-boto3-meteringmarketplace (>=1.21.0)", "mypy-boto3-mgh (>=1.21.0)", "mypy-boto3-mgn (>=1.21.0)", "mypy-boto3-migration-hub-refactor-spaces (>=1.21.0)", "mypy-boto3-migrationhub-config (>=1.21.0)", "mypy-boto3-migrationhubstrategy (>=1.21.0)", "mypy-boto3-mobile (>=1.21.0)", "mypy-boto3-mq (>=1.21.0)", "mypy-boto3-mturk (>=1.21.0)", "mypy-boto3-mwaa (>=1.21.0)", "mypy-boto3-neptune (>=1.21.0)", "mypy-boto3-network-firewall (>=1.21.0)", "mypy-boto3-networkmanager (>=1.21.0)", "mypy-boto3-nimble (>=1.21.0)", "mypy-boto3-opensearch (>=1.21.0)", "mypy-boto3-opsworks (>=1.21.0)", "mypy-boto3-opsworkscm (>=1.21.0)", "mypy-boto3-organizations (>=1.21.0)", "mypy-boto3-outposts (>=1.21.0)", "mypy-boto3-panorama (>=1.21.0)", "mypy-boto3-personalize (>=1.21.0)", "mypy-boto3-personalize-events (>=1.21.0)", "mypy-boto3-personalize-runtime (>=1.21.0)", "mypy-boto3-pi (>=1.21.0)", "mypy-boto3-pinpoint (>=1.21.0)", "mypy-boto3-pinpoint-email (>=1.21.0)", "mypy-boto3-pinpoint-sms-voice (>=1.21.0)", "mypy-boto3-polly (>=1.21.0)", "mypy-boto3-pricing (>=1.21.0)", "mypy-boto3-proton (>=1.21.0)", "mypy-boto3-qldb (>=1.21.0)", "mypy-boto3-qldb-session (>=1.21.0)", "mypy-boto3-quicksight (>=1.21.0)", "mypy-boto3-ram (>=1.21.0)", "mypy-boto3-rbin (>=1.21.0)", "mypy-boto3-rds (>=1.21.0)", "mypy-boto3-rds-data (>=1.21.0)", "mypy-boto3-redshift (>=1.21.0)", "mypy-boto3-redshift-data (>=1.21.0)", "mypy-boto3-rekognition (>=1.21.0)", "mypy-boto3-resiliencehub (>=1.21.0)", "mypy-boto3-resource-groups (>=1.21.0)", "mypy-boto3-resourcegroupstaggingapi (>=1.21.0)", "mypy-boto3-robomaker (>=1.21.0)", "mypy-boto3-route53 (>=1.21.0)", "mypy-boto3-route53-recovery-cluster (>=1.21.0)", "mypy-boto3-route53-recovery-control-config (>=1.21.0)", "mypy-boto3-route53-recovery-readiness (>=1.21.0)", "mypy-boto3-route53domains (>=1.21.0)", "mypy-boto3-route53resolver (>=1.21.0)", "mypy-boto3-rum (>=1.21.0)", "mypy-boto3-s3 (>=1.21.0)", "mypy-boto3-s3control (>=1.21.0)", "mypy-boto3-s3outposts (>=1.21.0)", "mypy-boto3-sagemaker (>=1.21.0)", "mypy-boto3-sagemaker-a2i-runtime (>=1.21.0)", "mypy-boto3-sagemaker-edge (>=1.21.0)", "mypy-boto3-sagemaker-featurestore-runtime (>=1.21.0)", "mypy-boto3-sagemaker-runtime (>=1.21.0)", "mypy-boto3-savingsplans (>=1.21.0)", "mypy-boto3-schemas (>=1.21.0)", "mypy-boto3-sdb (>=1.21.0)", "mypy-boto3-secretsmanager (>=1.21.0)", "mypy-boto3-securityhub (>=1.21.0)", "mypy-boto3-serverlessrepo (>=1.21.0)", "mypy-boto3-service-quotas (>=1.21.0)", "mypy-boto3-servicecatalog (>=1.21.0)", "mypy-boto3-servicecatalog-appregistry (>=1.21.0)", "mypy-boto3-servicediscovery (>=1.21.0)", "mypy-boto3-ses (>=1.21.0)", "mypy-boto3-sesv2 (>=1.21.0)", "mypy-boto3-shield (>=1.21.0)", "mypy-boto3-signer (>=1.21.0)", "mypy-boto3-sms (>=1.21.0)", "mypy-boto3-sms-voice (>=1.21.0)", "mypy-boto3-snow-device-management (>=1.21.0)", "mypy-boto3-snowball (>=1.21.0)", "mypy-boto3-sns (>=1.21.0)", "mypy-boto3-sqs (>=1.21.0)", "mypy-boto3-ssm (>=1.21.0)", "mypy-boto3-ssm-contacts (>=1.21.0)", "mypy-boto3-ssm-incidents (>=1.21.0)", "mypy-boto3-sso (>=1.21.0)", "mypy-boto3-sso-admin (>=1.21.0)", "mypy-boto3-sso-oidc (>=1.21.0)", "mypy-boto3-stepfunctions (>=1.21.0)", "mypy-boto3-storagegateway (>=1.21.0)", "mypy-boto3-sts (>=1.21.0)", "mypy-boto3-support (>=1.21.0)", "mypy-boto3-swf (>=1.21.0)", "mypy-boto3-synthetics (>=1.21.0)", "mypy-boto3-textract (>=1.21.0)", "mypy-boto3-timestream-query (>=1.21.0)", "mypy-boto3-timestream-write (>=1.21.0)", "mypy-boto3-transcribe (>=1.21.0)", "mypy-boto3-transfer (>=1.21.0)", "mypy-boto3-translate (>=1.21.0)", "mypy-boto3-voice-id (>=1.21.0)", "mypy-boto3-waf (>=1.21.0)", "mypy-boto3-waf-regional (>=1.21.0)", "mypy-boto3-wafv2 (>=1.21.0)", "mypy-boto3-wellarchitected (>=1.21.0)", "mypy-boto3-wisdom (>=1.21.0)", "mypy-boto3-workdocs (>=1.21.0)", "mypy-boto3-worklink (>=1.21.0)", "mypy-boto3-workmail (>=1.21.0)", "mypy-boto3-workmailmessageflow (>=1.21.0)", "mypy-boto3-workspaces (>=1.21.0)", "mypy-boto3-workspaces-web (>=1.21.0)", "mypy-boto3-xray (>=1.21.0)"]
-amp = ["mypy-boto3-amp (>=1.21.0)"]
-amplify = ["mypy-boto3-amplify (>=1.21.0)"]
-amplifybackend = ["mypy-boto3-amplifybackend (>=1.21.0)"]
-amplifyuibuilder = ["mypy-boto3-amplifyuibuilder (>=1.21.0)"]
-apigateway = ["mypy-boto3-apigateway (>=1.21.0)"]
-apigatewaymanagementapi = ["mypy-boto3-apigatewaymanagementapi (>=1.21.0)"]
-apigatewayv2 = ["mypy-boto3-apigatewayv2 (>=1.21.0)"]
-appconfig = ["mypy-boto3-appconfig (>=1.21.0)"]
-appconfigdata = ["mypy-boto3-appconfigdata (>=1.21.0)"]
-appflow = ["mypy-boto3-appflow (>=1.21.0)"]
-appintegrations = ["mypy-boto3-appintegrations (>=1.21.0)"]
-application-autoscaling = ["mypy-boto3-application-autoscaling (>=1.21.0)"]
-application-insights = ["mypy-boto3-application-insights (>=1.21.0)"]
-applicationcostprofiler = ["mypy-boto3-applicationcostprofiler (>=1.21.0)"]
-appmesh = ["mypy-boto3-appmesh (>=1.21.0)"]
-apprunner = ["mypy-boto3-apprunner (>=1.21.0)"]
-appstream = ["mypy-boto3-appstream (>=1.21.0)"]
-appsync = ["mypy-boto3-appsync (>=1.21.0)"]
-athena = ["mypy-boto3-athena (>=1.21.0)"]
-auditmanager = ["mypy-boto3-auditmanager (>=1.21.0)"]
-autoscaling = ["mypy-boto3-autoscaling (>=1.21.0)"]
-autoscaling-plans = ["mypy-boto3-autoscaling-plans (>=1.21.0)"]
-backup = ["mypy-boto3-backup (>=1.21.0)"]
-backup-gateway = ["mypy-boto3-backup-gateway (>=1.21.0)"]
-batch = ["mypy-boto3-batch (>=1.21.0)"]
-braket = ["mypy-boto3-braket (>=1.21.0)"]
-budgets = ["mypy-boto3-budgets (>=1.21.0)"]
-ce = ["mypy-boto3-ce (>=1.21.0)"]
-chime = ["mypy-boto3-chime (>=1.21.0)"]
-chime-sdk-identity = ["mypy-boto3-chime-sdk-identity (>=1.21.0)"]
-chime-sdk-meetings = ["mypy-boto3-chime-sdk-meetings (>=1.21.0)"]
-chime-sdk-messaging = ["mypy-boto3-chime-sdk-messaging (>=1.21.0)"]
-cloud9 = ["mypy-boto3-cloud9 (>=1.21.0)"]
-cloudcontrol = ["mypy-boto3-cloudcontrol (>=1.21.0)"]
-clouddirectory = ["mypy-boto3-clouddirectory (>=1.21.0)"]
-cloudformation = ["mypy-boto3-cloudformation (>=1.21.0)"]
-cloudfront = ["mypy-boto3-cloudfront (>=1.21.0)"]
-cloudhsm = ["mypy-boto3-cloudhsm (>=1.21.0)"]
-cloudhsmv2 = ["mypy-boto3-cloudhsmv2 (>=1.21.0)"]
-cloudsearch = ["mypy-boto3-cloudsearch (>=1.21.0)"]
-cloudsearchdomain = ["mypy-boto3-cloudsearchdomain (>=1.21.0)"]
-cloudtrail = ["mypy-boto3-cloudtrail (>=1.21.0)"]
-cloudwatch = ["mypy-boto3-cloudwatch (>=1.21.0)"]
-codeartifact = ["mypy-boto3-codeartifact (>=1.21.0)"]
-codebuild = ["mypy-boto3-codebuild (>=1.21.0)"]
-codecommit = ["mypy-boto3-codecommit (>=1.21.0)"]
-codedeploy = ["mypy-boto3-codedeploy (>=1.21.0)"]
-codeguru-reviewer = ["mypy-boto3-codeguru-reviewer (>=1.21.0)"]
-codeguruprofiler = ["mypy-boto3-codeguruprofiler (>=1.21.0)"]
-codepipeline = ["mypy-boto3-codepipeline (>=1.21.0)"]
-codestar = ["mypy-boto3-codestar (>=1.21.0)"]
-codestar-connections = ["mypy-boto3-codestar-connections (>=1.21.0)"]
-codestar-notifications = ["mypy-boto3-codestar-notifications (>=1.21.0)"]
-cognito-identity = ["mypy-boto3-cognito-identity (>=1.21.0)"]
-cognito-idp = ["mypy-boto3-cognito-idp (>=1.21.0)"]
-cognito-sync = ["mypy-boto3-cognito-sync (>=1.21.0)"]
-comprehend = ["mypy-boto3-comprehend (>=1.21.0)"]
-comprehendmedical = ["mypy-boto3-comprehendmedical (>=1.21.0)"]
-compute-optimizer = ["mypy-boto3-compute-optimizer (>=1.21.0)"]
-config = ["mypy-boto3-config (>=1.21.0)"]
-connect = ["mypy-boto3-connect (>=1.21.0)"]
-connect-contact-lens = ["mypy-boto3-connect-contact-lens (>=1.21.0)"]
-connectparticipant = ["mypy-boto3-connectparticipant (>=1.21.0)"]
-cur = ["mypy-boto3-cur (>=1.21.0)"]
-customer-profiles = ["mypy-boto3-customer-profiles (>=1.21.0)"]
-databrew = ["mypy-boto3-databrew (>=1.21.0)"]
-dataexchange = ["mypy-boto3-dataexchange (>=1.21.0)"]
-datapipeline = ["mypy-boto3-datapipeline (>=1.21.0)"]
-datasync = ["mypy-boto3-datasync (>=1.21.0)"]
-dax = ["mypy-boto3-dax (>=1.21.0)"]
-detective = ["mypy-boto3-detective (>=1.21.0)"]
-devicefarm = ["mypy-boto3-devicefarm (>=1.21.0)"]
-devops-guru = ["mypy-boto3-devops-guru (>=1.21.0)"]
-directconnect = ["mypy-boto3-directconnect (>=1.21.0)"]
-discovery = ["mypy-boto3-discovery (>=1.21.0)"]
-dlm = ["mypy-boto3-dlm (>=1.21.0)"]
-dms = ["mypy-boto3-dms (>=1.21.0)"]
-docdb = ["mypy-boto3-docdb (>=1.21.0)"]
-drs = ["mypy-boto3-drs (>=1.21.0)"]
-ds = ["mypy-boto3-ds (>=1.21.0)"]
-dynamodb = ["mypy-boto3-dynamodb (>=1.21.0)"]
-dynamodbstreams = ["mypy-boto3-dynamodbstreams (>=1.21.0)"]
-ebs = ["mypy-boto3-ebs (>=1.21.0)"]
-ec2 = ["mypy-boto3-ec2 (>=1.21.0)"]
-ec2-instance-connect = ["mypy-boto3-ec2-instance-connect (>=1.21.0)"]
-ecr = ["mypy-boto3-ecr (>=1.21.0)"]
-ecr-public = ["mypy-boto3-ecr-public (>=1.21.0)"]
-ecs = ["mypy-boto3-ecs (>=1.21.0)"]
-efs = ["mypy-boto3-efs (>=1.21.0)"]
-eks = ["mypy-boto3-eks (>=1.21.0)"]
-elastic-inference = ["mypy-boto3-elastic-inference (>=1.21.0)"]
-elasticache = ["mypy-boto3-elasticache (>=1.21.0)"]
-elasticbeanstalk = ["mypy-boto3-elasticbeanstalk (>=1.21.0)"]
-elastictranscoder = ["mypy-boto3-elastictranscoder (>=1.21.0)"]
-elb = ["mypy-boto3-elb (>=1.21.0)"]
-elbv2 = ["mypy-boto3-elbv2 (>=1.21.0)"]
-emr = ["mypy-boto3-emr (>=1.21.0)"]
-emr-containers = ["mypy-boto3-emr-containers (>=1.21.0)"]
-es = ["mypy-boto3-es (>=1.21.0)"]
-essential = ["mypy-boto3-cloudformation (>=1.21.0)", "mypy-boto3-dynamodb (>=1.21.0)", "mypy-boto3-ec2 (>=1.21.0)", "mypy-boto3-lambda (>=1.21.0)", "mypy-boto3-rds (>=1.21.0)", "mypy-boto3-s3 (>=1.21.0)", "mypy-boto3-sqs (>=1.21.0)"]
-events = ["mypy-boto3-events (>=1.21.0)"]
-evidently = ["mypy-boto3-evidently (>=1.21.0)"]
-finspace = ["mypy-boto3-finspace (>=1.21.0)"]
-finspace-data = ["mypy-boto3-finspace-data (>=1.21.0)"]
-firehose = ["mypy-boto3-firehose (>=1.21.0)"]
-fis = ["mypy-boto3-fis (>=1.21.0)"]
-fms = ["mypy-boto3-fms (>=1.21.0)"]
-forecast = ["mypy-boto3-forecast (>=1.21.0)"]
-forecastquery = ["mypy-boto3-forecastquery (>=1.21.0)"]
-frauddetector = ["mypy-boto3-frauddetector (>=1.21.0)"]
-fsx = ["mypy-boto3-fsx (>=1.21.0)"]
-gamelift = ["mypy-boto3-gamelift (>=1.21.0)"]
-glacier = ["mypy-boto3-glacier (>=1.21.0)"]
-globalaccelerator = ["mypy-boto3-globalaccelerator (>=1.21.0)"]
-glue = ["mypy-boto3-glue (>=1.21.0)"]
-grafana = ["mypy-boto3-grafana (>=1.21.0)"]
-greengrass = ["mypy-boto3-greengrass (>=1.21.0)"]
-greengrassv2 = ["mypy-boto3-greengrassv2 (>=1.21.0)"]
-groundstation = ["mypy-boto3-groundstation (>=1.21.0)"]
-guardduty = ["mypy-boto3-guardduty (>=1.21.0)"]
-health = ["mypy-boto3-health (>=1.21.0)"]
-healthlake = ["mypy-boto3-healthlake (>=1.21.0)"]
-honeycode = ["mypy-boto3-honeycode (>=1.21.0)"]
-iam = ["mypy-boto3-iam (>=1.21.0)"]
-identitystore = ["mypy-boto3-identitystore (>=1.21.0)"]
-imagebuilder = ["mypy-boto3-imagebuilder (>=1.21.0)"]
-importexport = ["mypy-boto3-importexport (>=1.21.0)"]
-inspector = ["mypy-boto3-inspector (>=1.21.0)"]
-inspector2 = ["mypy-boto3-inspector2 (>=1.21.0)"]
-iot = ["mypy-boto3-iot (>=1.21.0)"]
-iot-data = ["mypy-boto3-iot-data (>=1.21.0)"]
-iot-jobs-data = ["mypy-boto3-iot-jobs-data (>=1.21.0)"]
-iot1click-devices = ["mypy-boto3-iot1click-devices (>=1.21.0)"]
-iot1click-projects = ["mypy-boto3-iot1click-projects (>=1.21.0)"]
-iotanalytics = ["mypy-boto3-iotanalytics (>=1.21.0)"]
-iotdeviceadvisor = ["mypy-boto3-iotdeviceadvisor (>=1.21.0)"]
-iotevents = ["mypy-boto3-iotevents (>=1.21.0)"]
-iotevents-data = ["mypy-boto3-iotevents-data (>=1.21.0)"]
-iotfleethub = ["mypy-boto3-iotfleethub (>=1.21.0)"]
-iotsecuretunneling = ["mypy-boto3-iotsecuretunneling (>=1.21.0)"]
-iotsitewise = ["mypy-boto3-iotsitewise (>=1.21.0)"]
-iotthingsgraph = ["mypy-boto3-iotthingsgraph (>=1.21.0)"]
-iottwinmaker = ["mypy-boto3-iottwinmaker (>=1.21.0)"]
-iotwireless = ["mypy-boto3-iotwireless (>=1.21.0)"]
-ivs = ["mypy-boto3-ivs (>=1.21.0)"]
-kafka = ["mypy-boto3-kafka (>=1.21.0)"]
-kafkaconnect = ["mypy-boto3-kafkaconnect (>=1.21.0)"]
-kendra = ["mypy-boto3-kendra (>=1.21.0)"]
-keyspaces = ["mypy-boto3-keyspaces (>=1.21.0)"]
-kinesis = ["mypy-boto3-kinesis (>=1.21.0)"]
-kinesis-video-archived-media = ["mypy-boto3-kinesis-video-archived-media (>=1.21.0)"]
-kinesis-video-media = ["mypy-boto3-kinesis-video-media (>=1.21.0)"]
-kinesis-video-signaling = ["mypy-boto3-kinesis-video-signaling (>=1.21.0)"]
-kinesisanalytics = ["mypy-boto3-kinesisanalytics (>=1.21.0)"]
-kinesisanalyticsv2 = ["mypy-boto3-kinesisanalyticsv2 (>=1.21.0)"]
-kinesisvideo = ["mypy-boto3-kinesisvideo (>=1.21.0)"]
-kms = ["mypy-boto3-kms (>=1.21.0)"]
-lakeformation = ["mypy-boto3-lakeformation (>=1.21.0)"]
-lambda = ["mypy-boto3-lambda (>=1.21.0)"]
-lex-models = ["mypy-boto3-lex-models (>=1.21.0)"]
-lex-runtime = ["mypy-boto3-lex-runtime (>=1.21.0)"]
-lexv2-models = ["mypy-boto3-lexv2-models (>=1.21.0)"]
-lexv2-runtime = ["mypy-boto3-lexv2-runtime (>=1.21.0)"]
-license-manager = ["mypy-boto3-license-manager (>=1.21.0)"]
-lightsail = ["mypy-boto3-lightsail (>=1.21.0)"]
-location = ["mypy-boto3-location (>=1.21.0)"]
-logs = ["mypy-boto3-logs (>=1.21.0)"]
-lookoutequipment = ["mypy-boto3-lookoutequipment (>=1.21.0)"]
-lookoutmetrics = ["mypy-boto3-lookoutmetrics (>=1.21.0)"]
-lookoutvision = ["mypy-boto3-lookoutvision (>=1.21.0)"]
-machinelearning = ["mypy-boto3-machinelearning (>=1.21.0)"]
-macie = ["mypy-boto3-macie (>=1.21.0)"]
-macie2 = ["mypy-boto3-macie2 (>=1.21.0)"]
-managedblockchain = ["mypy-boto3-managedblockchain (>=1.21.0)"]
-marketplace-catalog = ["mypy-boto3-marketplace-catalog (>=1.21.0)"]
-marketplace-entitlement = ["mypy-boto3-marketplace-entitlement (>=1.21.0)"]
-marketplacecommerceanalytics = ["mypy-boto3-marketplacecommerceanalytics (>=1.21.0)"]
-mediaconnect = ["mypy-boto3-mediaconnect (>=1.21.0)"]
-mediaconvert = ["mypy-boto3-mediaconvert (>=1.21.0)"]
-medialive = ["mypy-boto3-medialive (>=1.21.0)"]
-mediapackage = ["mypy-boto3-mediapackage (>=1.21.0)"]
-mediapackage-vod = ["mypy-boto3-mediapackage-vod (>=1.21.0)"]
-mediastore = ["mypy-boto3-mediastore (>=1.21.0)"]
-mediastore-data = ["mypy-boto3-mediastore-data (>=1.21.0)"]
-mediatailor = ["mypy-boto3-mediatailor (>=1.21.0)"]
-memorydb = ["mypy-boto3-memorydb (>=1.21.0)"]
-meteringmarketplace = ["mypy-boto3-meteringmarketplace (>=1.21.0)"]
-mgh = ["mypy-boto3-mgh (>=1.21.0)"]
-mgn = ["mypy-boto3-mgn (>=1.21.0)"]
-migration-hub-refactor-spaces = ["mypy-boto3-migration-hub-refactor-spaces (>=1.21.0)"]
-migrationhub-config = ["mypy-boto3-migrationhub-config (>=1.21.0)"]
-migrationhubstrategy = ["mypy-boto3-migrationhubstrategy (>=1.21.0)"]
-mobile = ["mypy-boto3-mobile (>=1.21.0)"]
-mq = ["mypy-boto3-mq (>=1.21.0)"]
-mturk = ["mypy-boto3-mturk (>=1.21.0)"]
-mwaa = ["mypy-boto3-mwaa (>=1.21.0)"]
-neptune = ["mypy-boto3-neptune (>=1.21.0)"]
-network-firewall = ["mypy-boto3-network-firewall (>=1.21.0)"]
-networkmanager = ["mypy-boto3-networkmanager (>=1.21.0)"]
-nimble = ["mypy-boto3-nimble (>=1.21.0)"]
-opensearch = ["mypy-boto3-opensearch (>=1.21.0)"]
-opsworks = ["mypy-boto3-opsworks (>=1.21.0)"]
-opsworkscm = ["mypy-boto3-opsworkscm (>=1.21.0)"]
-organizations = ["mypy-boto3-organizations (>=1.21.0)"]
-outposts = ["mypy-boto3-outposts (>=1.21.0)"]
-panorama = ["mypy-boto3-panorama (>=1.21.0)"]
-personalize = ["mypy-boto3-personalize (>=1.21.0)"]
-personalize-events = ["mypy-boto3-personalize-events (>=1.21.0)"]
-personalize-runtime = ["mypy-boto3-personalize-runtime (>=1.21.0)"]
-pi = ["mypy-boto3-pi (>=1.21.0)"]
-pinpoint = ["mypy-boto3-pinpoint (>=1.21.0)"]
-pinpoint-email = ["mypy-boto3-pinpoint-email (>=1.21.0)"]
-pinpoint-sms-voice = ["mypy-boto3-pinpoint-sms-voice (>=1.21.0)"]
-polly = ["mypy-boto3-polly (>=1.21.0)"]
-pricing = ["mypy-boto3-pricing (>=1.21.0)"]
-proton = ["mypy-boto3-proton (>=1.21.0)"]
-qldb = ["mypy-boto3-qldb (>=1.21.0)"]
-qldb-session = ["mypy-boto3-qldb-session (>=1.21.0)"]
-quicksight = ["mypy-boto3-quicksight (>=1.21.0)"]
-ram = ["mypy-boto3-ram (>=1.21.0)"]
-rbin = ["mypy-boto3-rbin (>=1.21.0)"]
-rds = ["mypy-boto3-rds (>=1.21.0)"]
-rds-data = ["mypy-boto3-rds-data (>=1.21.0)"]
-redshift = ["mypy-boto3-redshift (>=1.21.0)"]
-redshift-data = ["mypy-boto3-redshift-data (>=1.21.0)"]
-rekognition = ["mypy-boto3-rekognition (>=1.21.0)"]
-resiliencehub = ["mypy-boto3-resiliencehub (>=1.21.0)"]
-resource-groups = ["mypy-boto3-resource-groups (>=1.21.0)"]
-resourcegroupstaggingapi = ["mypy-boto3-resourcegroupstaggingapi (>=1.21.0)"]
-robomaker = ["mypy-boto3-robomaker (>=1.21.0)"]
-route53 = ["mypy-boto3-route53 (>=1.21.0)"]
-route53-recovery-cluster = ["mypy-boto3-route53-recovery-cluster (>=1.21.0)"]
-route53-recovery-control-config = ["mypy-boto3-route53-recovery-control-config (>=1.21.0)"]
-route53-recovery-readiness = ["mypy-boto3-route53-recovery-readiness (>=1.21.0)"]
-route53domains = ["mypy-boto3-route53domains (>=1.21.0)"]
-route53resolver = ["mypy-boto3-route53resolver (>=1.21.0)"]
-rum = ["mypy-boto3-rum (>=1.21.0)"]
-s3 = ["mypy-boto3-s3 (>=1.21.0)"]
-s3control = ["mypy-boto3-s3control (>=1.21.0)"]
-s3outposts = ["mypy-boto3-s3outposts (>=1.21.0)"]
-sagemaker = ["mypy-boto3-sagemaker (>=1.21.0)"]
-sagemaker-a2i-runtime = ["mypy-boto3-sagemaker-a2i-runtime (>=1.21.0)"]
-sagemaker-edge = ["mypy-boto3-sagemaker-edge (>=1.21.0)"]
-sagemaker-featurestore-runtime = ["mypy-boto3-sagemaker-featurestore-runtime (>=1.21.0)"]
-sagemaker-runtime = ["mypy-boto3-sagemaker-runtime (>=1.21.0)"]
-savingsplans = ["mypy-boto3-savingsplans (>=1.21.0)"]
-schemas = ["mypy-boto3-schemas (>=1.21.0)"]
-sdb = ["mypy-boto3-sdb (>=1.21.0)"]
-secretsmanager = ["mypy-boto3-secretsmanager (>=1.21.0)"]
-securityhub = ["mypy-boto3-securityhub (>=1.21.0)"]
-serverlessrepo = ["mypy-boto3-serverlessrepo (>=1.21.0)"]
-service-quotas = ["mypy-boto3-service-quotas (>=1.21.0)"]
-servicecatalog = ["mypy-boto3-servicecatalog (>=1.21.0)"]
-servicecatalog-appregistry = ["mypy-boto3-servicecatalog-appregistry (>=1.21.0)"]
-servicediscovery = ["mypy-boto3-servicediscovery (>=1.21.0)"]
-ses = ["mypy-boto3-ses (>=1.21.0)"]
-sesv2 = ["mypy-boto3-sesv2 (>=1.21.0)"]
-shield = ["mypy-boto3-shield (>=1.21.0)"]
-signer = ["mypy-boto3-signer (>=1.21.0)"]
-sms = ["mypy-boto3-sms (>=1.21.0)"]
-sms-voice = ["mypy-boto3-sms-voice (>=1.21.0)"]
-snow-device-management = ["mypy-boto3-snow-device-management (>=1.21.0)"]
-snowball = ["mypy-boto3-snowball (>=1.21.0)"]
-sns = ["mypy-boto3-sns (>=1.21.0)"]
-sqs = ["mypy-boto3-sqs (>=1.21.0)"]
-ssm = ["mypy-boto3-ssm (>=1.21.0)"]
-ssm-contacts = ["mypy-boto3-ssm-contacts (>=1.21.0)"]
-ssm-incidents = ["mypy-boto3-ssm-incidents (>=1.21.0)"]
-sso = ["mypy-boto3-sso (>=1.21.0)"]
-sso-admin = ["mypy-boto3-sso-admin (>=1.21.0)"]
-sso-oidc = ["mypy-boto3-sso-oidc (>=1.21.0)"]
-stepfunctions = ["mypy-boto3-stepfunctions (>=1.21.0)"]
-storagegateway = ["mypy-boto3-storagegateway (>=1.21.0)"]
-sts = ["mypy-boto3-sts (>=1.21.0)"]
-support = ["mypy-boto3-support (>=1.21.0)"]
-swf = ["mypy-boto3-swf (>=1.21.0)"]
-synthetics = ["mypy-boto3-synthetics (>=1.21.0)"]
-textract = ["mypy-boto3-textract (>=1.21.0)"]
-timestream-query = ["mypy-boto3-timestream-query (>=1.21.0)"]
-timestream-write = ["mypy-boto3-timestream-write (>=1.21.0)"]
-transcribe = ["mypy-boto3-transcribe (>=1.21.0)"]
-transfer = ["mypy-boto3-transfer (>=1.21.0)"]
-translate = ["mypy-boto3-translate (>=1.21.0)"]
-voice-id = ["mypy-boto3-voice-id (>=1.21.0)"]
-waf = ["mypy-boto3-waf (>=1.21.0)"]
-waf-regional = ["mypy-boto3-waf-regional (>=1.21.0)"]
-wafv2 = ["mypy-boto3-wafv2 (>=1.21.0)"]
-wellarchitected = ["mypy-boto3-wellarchitected (>=1.21.0)"]
-wisdom = ["mypy-boto3-wisdom (>=1.21.0)"]
-workdocs = ["mypy-boto3-workdocs (>=1.21.0)"]
-worklink = ["mypy-boto3-worklink (>=1.21.0)"]
-workmail = ["mypy-boto3-workmail (>=1.21.0)"]
-workmailmessageflow = ["mypy-boto3-workmailmessageflow (>=1.21.0)"]
-workspaces = ["mypy-boto3-workspaces (>=1.21.0)"]
-workspaces-web = ["mypy-boto3-workspaces-web (>=1.21.0)"]
-xray = ["mypy-boto3-xray (>=1.21.0)"]
-
-[[package]]
 name = "botocore"
-version = "1.24.13"
+version = "1.24.14"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -393,17 +74,6 @@ urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
 crt = ["awscrt (==0.12.5)"]
-
-[[package]]
-name = "botocore-stubs"
-version = "1.24.13"
-description = "Type annotations for botocore 1.24.13 generated with mypy-boto3-builder 7.3.0"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "certifi"
@@ -635,39 +305,6 @@ ssm = ["PyYAML (>=5.1)", "dataclasses"]
 xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
 [[package]]
-name = "mypy-boto3-cloudformation"
-version = "1.21.0"
-description = "Type annotations for boto3.CloudFormation 1.21.0 service generated by mypy-boto3-builder 7.0.4"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
-
-[[package]]
-name = "mypy-boto3-codecommit"
-version = "1.21.0"
-description = "Type annotations for boto3.CodeCommit 1.21.0 service generated by mypy-boto3-builder 7.0.4"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
-
-[[package]]
-name = "mypy-boto3-sts"
-version = "1.21.13"
-description = "Type annotations for boto3.STS 1.21.13 service generated with mypy-boto3-builder 7.3.0"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
-
-[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -819,7 +456,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "responses"
-version = "0.18.0"
+version = "0.19.0"
 description = "A utility library for mocking out the `requests` Python library."
 category = "dev"
 optional = false
@@ -830,7 +467,7 @@ requests = ">=2.0,<3.0"
 urllib3 = ">=1.25.10"
 
 [package.extras]
-tests = ["pytest (>=4.6)", "coverage (>=6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "types-mock", "types-requests", "mypy"]
+tests = ["pytest (>=7.0.0)", "coverage (>=6.0.0)", "pytest-cov", "pytest-asyncio", "pytest-localserver", "flake8", "types-mock", "types-requests", "mypy"]
 
 [[package]]
 name = "s3transfer"
@@ -938,7 +575,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <3.11"
-content-hash = "a36ba2cdd3700cced91e36e4425e9a0625bf8b87fd9f31ccee1c6c4fd3f3b2f0"
+content-hash = "82d1d3dde09c4aa10f2ad450770d587f39bbdc15d26396dfd7fded8352a1ef84"
 
 [metadata.files]
 arrow = [
@@ -958,20 +595,12 @@ binaryornot = [
     {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
 ]
 boto3 = [
-    {file = "boto3-1.21.13-py3-none-any.whl", hash = "sha256:e17d994d222162dac02ec32fde6ae910d819ebf239a94dddcee47def2c82b9c9"},
-    {file = "boto3-1.21.13.tar.gz", hash = "sha256:16fae86d0c4993fd5112128bb4622a879f02363bccd045153cc0bbd7722cc9a5"},
-]
-boto3-stubs-lite = [
-    {file = "boto3-stubs-lite-1.21.13.tar.gz", hash = "sha256:d57aadd66b8863eb82b71ef85b346b979e32c0843d490537ecdea12fe9e10aa4"},
-    {file = "boto3_stubs_lite-1.21.13-py3-none-any.whl", hash = "sha256:a333855642fe38bad1d8245495a622c7c0b3c3c2253788014ab0558e42f830c1"},
+    {file = "boto3-1.21.14-py3-none-any.whl", hash = "sha256:d674fcd10c9603984599157941db66aa212d217dd073581c0ba2eab5e5da84fa"},
+    {file = "boto3-1.21.14.tar.gz", hash = "sha256:20d29e7b845eed3a39b43633443859bfa719ddbe3c8702ddfd999bc737fba9db"},
 ]
 botocore = [
-    {file = "botocore-1.24.13-py3-none-any.whl", hash = "sha256:7b166096f9413b41caf7cc6f4edfd5b3c3ab9d7c61eb120a649e69485c98131a"},
-    {file = "botocore-1.24.13.tar.gz", hash = "sha256:46e51f56f1c5784e4245e036503635fa71b722775657b6e1acf21ec5b906974c"},
-]
-botocore-stubs = [
-    {file = "botocore-stubs-1.24.13.tar.gz", hash = "sha256:eddcb423f18817cad8f4fcba4db8f24ebb21f16a5c0e28e09771099edb47fcce"},
-    {file = "botocore_stubs-1.24.13-py3-none-any.whl", hash = "sha256:d172f4dde2df15c90bb6926801fe8cc6fad4d91d094faf35c34f69b8203d2b57"},
+    {file = "botocore-1.24.14-py3-none-any.whl", hash = "sha256:2c40f4fc3925b9057869beda1413a7b77edb7a28eb05c6265eaf6ca1ca7d3b63"},
+    {file = "botocore-1.24.14.tar.gz", hash = "sha256:9fe55f6eab0977b00afd90e770ef2c8b989fa7b18e5c14b22ba62216ec3b564a"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -1145,18 +774,6 @@ moto = [
     {file = "moto-2.3.2-py2.py3-none-any.whl", hash = "sha256:0c29f5813d4db69b2f99c5538909a5aba0ba1cb91a74c19eddd9bfdc39ed2ff3"},
     {file = "moto-2.3.2.tar.gz", hash = "sha256:eaaed229742adbd1387383d113350ecd9222fc1e8f5611a9395a058c1eee4377"},
 ]
-mypy-boto3-cloudformation = [
-    {file = "mypy-boto3-cloudformation-1.21.0.tar.gz", hash = "sha256:f4eae0189897a060646d95f1c6e4644081d961b95c007dd1c1fbd3a0fa21616f"},
-    {file = "mypy_boto3_cloudformation-1.21.0-py3-none-any.whl", hash = "sha256:8c138380e9ccd6fa5ac6eb5c7f8a8c5f77005492cb26ca6b5b4fe19f2f199162"},
-]
-mypy-boto3-codecommit = [
-    {file = "mypy-boto3-codecommit-1.21.0.tar.gz", hash = "sha256:ed1261e36a15d75b1958e6809e268ad24de47b8c18983e483214aaef9f96ebfe"},
-    {file = "mypy_boto3_codecommit-1.21.0-py3-none-any.whl", hash = "sha256:ac438d5c79c112cd8ab70478afb8d1fd7917e6d1af5961a0f0ed1f0668a37064"},
-]
-mypy-boto3-sts = [
-    {file = "mypy-boto3-sts-1.21.13.tar.gz", hash = "sha256:b62d9f597826ba4668f9f3500dd6c74b71f55510de7f69d59df76a9ed4bc16c6"},
-    {file = "mypy_boto3_sts-1.21.13-py3-none-any.whl", hash = "sha256:452586399235f82d90b201a62a7c4a045d51eda34fb721f795a7f24c08b4c0e1"},
-]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -1247,8 +864,8 @@ requests = [
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 responses = [
-    {file = "responses-0.18.0-py3-none-any.whl", hash = "sha256:15c63ad16de13ee8e7182d99c9334f64fd81f1ee79f90748d527c28f7ca9dd51"},
-    {file = "responses-0.18.0.tar.gz", hash = "sha256:380cad4c1c1dc942e5e8a8eaae0b4d4edf708f4f010db8b7bcfafad1fcd254ff"},
+    {file = "responses-0.19.0-py3-none-any.whl", hash = "sha256:53354b5de163aa2074312c71d8ebccb8bd1ab336cff7053abb75e84dc5637abe"},
+    {file = "responses-0.19.0.tar.gz", hash = "sha256:3fc29c3117e14136b833a0a6d4e7f1217c6301bf08b6086db468e12f1e3290e2"},
 ]
 s3transfer = [
     {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -45,14 +45,14 @@ chardet = ">=3.0.2"
 
 [[package]]
 name = "boto3"
-version = "1.21.2"
+version = "1.21.13"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.24.2,<1.25.0"
+botocore = ">=1.24.13,<1.25.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -60,8 +60,327 @@ s3transfer = ">=0.5.0,<0.6.0"
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
+name = "boto3-stubs-lite"
+version = "1.21.13"
+description = "Type annotations for boto3 1.21.13 generated with mypy-boto3-builder 7.3.0"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+botocore-stubs = "*"
+mypy-boto3-cloudformation = {version = ">=1.21.0", optional = true, markers = "extra == \"cloudformation\""}
+mypy-boto3-codecommit = {version = ">=1.21.0", optional = true, markers = "extra == \"codecommit\""}
+mypy-boto3-sts = {version = ">=1.21.0", optional = true, markers = "extra == \"sts\""}
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
+
+[package.extras]
+accessanalyzer = ["mypy-boto3-accessanalyzer (>=1.21.0)"]
+account = ["mypy-boto3-account (>=1.21.0)"]
+acm = ["mypy-boto3-acm (>=1.21.0)"]
+acm-pca = ["mypy-boto3-acm-pca (>=1.21.0)"]
+alexaforbusiness = ["mypy-boto3-alexaforbusiness (>=1.21.0)"]
+all = ["mypy-boto3-accessanalyzer (>=1.21.0)", "mypy-boto3-account (>=1.21.0)", "mypy-boto3-acm (>=1.21.0)", "mypy-boto3-acm-pca (>=1.21.0)", "mypy-boto3-alexaforbusiness (>=1.21.0)", "mypy-boto3-amp (>=1.21.0)", "mypy-boto3-amplify (>=1.21.0)", "mypy-boto3-amplifybackend (>=1.21.0)", "mypy-boto3-amplifyuibuilder (>=1.21.0)", "mypy-boto3-apigateway (>=1.21.0)", "mypy-boto3-apigatewaymanagementapi (>=1.21.0)", "mypy-boto3-apigatewayv2 (>=1.21.0)", "mypy-boto3-appconfig (>=1.21.0)", "mypy-boto3-appconfigdata (>=1.21.0)", "mypy-boto3-appflow (>=1.21.0)", "mypy-boto3-appintegrations (>=1.21.0)", "mypy-boto3-application-autoscaling (>=1.21.0)", "mypy-boto3-application-insights (>=1.21.0)", "mypy-boto3-applicationcostprofiler (>=1.21.0)", "mypy-boto3-appmesh (>=1.21.0)", "mypy-boto3-apprunner (>=1.21.0)", "mypy-boto3-appstream (>=1.21.0)", "mypy-boto3-appsync (>=1.21.0)", "mypy-boto3-athena (>=1.21.0)", "mypy-boto3-auditmanager (>=1.21.0)", "mypy-boto3-autoscaling (>=1.21.0)", "mypy-boto3-autoscaling-plans (>=1.21.0)", "mypy-boto3-backup (>=1.21.0)", "mypy-boto3-backup-gateway (>=1.21.0)", "mypy-boto3-batch (>=1.21.0)", "mypy-boto3-braket (>=1.21.0)", "mypy-boto3-budgets (>=1.21.0)", "mypy-boto3-ce (>=1.21.0)", "mypy-boto3-chime (>=1.21.0)", "mypy-boto3-chime-sdk-identity (>=1.21.0)", "mypy-boto3-chime-sdk-meetings (>=1.21.0)", "mypy-boto3-chime-sdk-messaging (>=1.21.0)", "mypy-boto3-cloud9 (>=1.21.0)", "mypy-boto3-cloudcontrol (>=1.21.0)", "mypy-boto3-clouddirectory (>=1.21.0)", "mypy-boto3-cloudformation (>=1.21.0)", "mypy-boto3-cloudfront (>=1.21.0)", "mypy-boto3-cloudhsm (>=1.21.0)", "mypy-boto3-cloudhsmv2 (>=1.21.0)", "mypy-boto3-cloudsearch (>=1.21.0)", "mypy-boto3-cloudsearchdomain (>=1.21.0)", "mypy-boto3-cloudtrail (>=1.21.0)", "mypy-boto3-cloudwatch (>=1.21.0)", "mypy-boto3-codeartifact (>=1.21.0)", "mypy-boto3-codebuild (>=1.21.0)", "mypy-boto3-codecommit (>=1.21.0)", "mypy-boto3-codedeploy (>=1.21.0)", "mypy-boto3-codeguru-reviewer (>=1.21.0)", "mypy-boto3-codeguruprofiler (>=1.21.0)", "mypy-boto3-codepipeline (>=1.21.0)", "mypy-boto3-codestar (>=1.21.0)", "mypy-boto3-codestar-connections (>=1.21.0)", "mypy-boto3-codestar-notifications (>=1.21.0)", "mypy-boto3-cognito-identity (>=1.21.0)", "mypy-boto3-cognito-idp (>=1.21.0)", "mypy-boto3-cognito-sync (>=1.21.0)", "mypy-boto3-comprehend (>=1.21.0)", "mypy-boto3-comprehendmedical (>=1.21.0)", "mypy-boto3-compute-optimizer (>=1.21.0)", "mypy-boto3-config (>=1.21.0)", "mypy-boto3-connect (>=1.21.0)", "mypy-boto3-connect-contact-lens (>=1.21.0)", "mypy-boto3-connectparticipant (>=1.21.0)", "mypy-boto3-cur (>=1.21.0)", "mypy-boto3-customer-profiles (>=1.21.0)", "mypy-boto3-databrew (>=1.21.0)", "mypy-boto3-dataexchange (>=1.21.0)", "mypy-boto3-datapipeline (>=1.21.0)", "mypy-boto3-datasync (>=1.21.0)", "mypy-boto3-dax (>=1.21.0)", "mypy-boto3-detective (>=1.21.0)", "mypy-boto3-devicefarm (>=1.21.0)", "mypy-boto3-devops-guru (>=1.21.0)", "mypy-boto3-directconnect (>=1.21.0)", "mypy-boto3-discovery (>=1.21.0)", "mypy-boto3-dlm (>=1.21.0)", "mypy-boto3-dms (>=1.21.0)", "mypy-boto3-docdb (>=1.21.0)", "mypy-boto3-drs (>=1.21.0)", "mypy-boto3-ds (>=1.21.0)", "mypy-boto3-dynamodb (>=1.21.0)", "mypy-boto3-dynamodbstreams (>=1.21.0)", "mypy-boto3-ebs (>=1.21.0)", "mypy-boto3-ec2 (>=1.21.0)", "mypy-boto3-ec2-instance-connect (>=1.21.0)", "mypy-boto3-ecr (>=1.21.0)", "mypy-boto3-ecr-public (>=1.21.0)", "mypy-boto3-ecs (>=1.21.0)", "mypy-boto3-efs (>=1.21.0)", "mypy-boto3-eks (>=1.21.0)", "mypy-boto3-elastic-inference (>=1.21.0)", "mypy-boto3-elasticache (>=1.21.0)", "mypy-boto3-elasticbeanstalk (>=1.21.0)", "mypy-boto3-elastictranscoder (>=1.21.0)", "mypy-boto3-elb (>=1.21.0)", "mypy-boto3-elbv2 (>=1.21.0)", "mypy-boto3-emr (>=1.21.0)", "mypy-boto3-emr-containers (>=1.21.0)", "mypy-boto3-es (>=1.21.0)", "mypy-boto3-events (>=1.21.0)", "mypy-boto3-evidently (>=1.21.0)", "mypy-boto3-finspace (>=1.21.0)", "mypy-boto3-finspace-data (>=1.21.0)", "mypy-boto3-firehose (>=1.21.0)", "mypy-boto3-fis (>=1.21.0)", "mypy-boto3-fms (>=1.21.0)", "mypy-boto3-forecast (>=1.21.0)", "mypy-boto3-forecastquery (>=1.21.0)", "mypy-boto3-frauddetector (>=1.21.0)", "mypy-boto3-fsx (>=1.21.0)", "mypy-boto3-gamelift (>=1.21.0)", "mypy-boto3-glacier (>=1.21.0)", "mypy-boto3-globalaccelerator (>=1.21.0)", "mypy-boto3-glue (>=1.21.0)", "mypy-boto3-grafana (>=1.21.0)", "mypy-boto3-greengrass (>=1.21.0)", "mypy-boto3-greengrassv2 (>=1.21.0)", "mypy-boto3-groundstation (>=1.21.0)", "mypy-boto3-guardduty (>=1.21.0)", "mypy-boto3-health (>=1.21.0)", "mypy-boto3-healthlake (>=1.21.0)", "mypy-boto3-honeycode (>=1.21.0)", "mypy-boto3-iam (>=1.21.0)", "mypy-boto3-identitystore (>=1.21.0)", "mypy-boto3-imagebuilder (>=1.21.0)", "mypy-boto3-importexport (>=1.21.0)", "mypy-boto3-inspector (>=1.21.0)", "mypy-boto3-inspector2 (>=1.21.0)", "mypy-boto3-iot (>=1.21.0)", "mypy-boto3-iot-data (>=1.21.0)", "mypy-boto3-iot-jobs-data (>=1.21.0)", "mypy-boto3-iot1click-devices (>=1.21.0)", "mypy-boto3-iot1click-projects (>=1.21.0)", "mypy-boto3-iotanalytics (>=1.21.0)", "mypy-boto3-iotdeviceadvisor (>=1.21.0)", "mypy-boto3-iotevents (>=1.21.0)", "mypy-boto3-iotevents-data (>=1.21.0)", "mypy-boto3-iotfleethub (>=1.21.0)", "mypy-boto3-iotsecuretunneling (>=1.21.0)", "mypy-boto3-iotsitewise (>=1.21.0)", "mypy-boto3-iotthingsgraph (>=1.21.0)", "mypy-boto3-iottwinmaker (>=1.21.0)", "mypy-boto3-iotwireless (>=1.21.0)", "mypy-boto3-ivs (>=1.21.0)", "mypy-boto3-kafka (>=1.21.0)", "mypy-boto3-kafkaconnect (>=1.21.0)", "mypy-boto3-kendra (>=1.21.0)", "mypy-boto3-keyspaces (>=1.21.0)", "mypy-boto3-kinesis (>=1.21.0)", "mypy-boto3-kinesis-video-archived-media (>=1.21.0)", "mypy-boto3-kinesis-video-media (>=1.21.0)", "mypy-boto3-kinesis-video-signaling (>=1.21.0)", "mypy-boto3-kinesisanalytics (>=1.21.0)", "mypy-boto3-kinesisanalyticsv2 (>=1.21.0)", "mypy-boto3-kinesisvideo (>=1.21.0)", "mypy-boto3-kms (>=1.21.0)", "mypy-boto3-lakeformation (>=1.21.0)", "mypy-boto3-lambda (>=1.21.0)", "mypy-boto3-lex-models (>=1.21.0)", "mypy-boto3-lex-runtime (>=1.21.0)", "mypy-boto3-lexv2-models (>=1.21.0)", "mypy-boto3-lexv2-runtime (>=1.21.0)", "mypy-boto3-license-manager (>=1.21.0)", "mypy-boto3-lightsail (>=1.21.0)", "mypy-boto3-location (>=1.21.0)", "mypy-boto3-logs (>=1.21.0)", "mypy-boto3-lookoutequipment (>=1.21.0)", "mypy-boto3-lookoutmetrics (>=1.21.0)", "mypy-boto3-lookoutvision (>=1.21.0)", "mypy-boto3-machinelearning (>=1.21.0)", "mypy-boto3-macie (>=1.21.0)", "mypy-boto3-macie2 (>=1.21.0)", "mypy-boto3-managedblockchain (>=1.21.0)", "mypy-boto3-marketplace-catalog (>=1.21.0)", "mypy-boto3-marketplace-entitlement (>=1.21.0)", "mypy-boto3-marketplacecommerceanalytics (>=1.21.0)", "mypy-boto3-mediaconnect (>=1.21.0)", "mypy-boto3-mediaconvert (>=1.21.0)", "mypy-boto3-medialive (>=1.21.0)", "mypy-boto3-mediapackage (>=1.21.0)", "mypy-boto3-mediapackage-vod (>=1.21.0)", "mypy-boto3-mediastore (>=1.21.0)", "mypy-boto3-mediastore-data (>=1.21.0)", "mypy-boto3-mediatailor (>=1.21.0)", "mypy-boto3-memorydb (>=1.21.0)", "mypy-boto3-meteringmarketplace (>=1.21.0)", "mypy-boto3-mgh (>=1.21.0)", "mypy-boto3-mgn (>=1.21.0)", "mypy-boto3-migration-hub-refactor-spaces (>=1.21.0)", "mypy-boto3-migrationhub-config (>=1.21.0)", "mypy-boto3-migrationhubstrategy (>=1.21.0)", "mypy-boto3-mobile (>=1.21.0)", "mypy-boto3-mq (>=1.21.0)", "mypy-boto3-mturk (>=1.21.0)", "mypy-boto3-mwaa (>=1.21.0)", "mypy-boto3-neptune (>=1.21.0)", "mypy-boto3-network-firewall (>=1.21.0)", "mypy-boto3-networkmanager (>=1.21.0)", "mypy-boto3-nimble (>=1.21.0)", "mypy-boto3-opensearch (>=1.21.0)", "mypy-boto3-opsworks (>=1.21.0)", "mypy-boto3-opsworkscm (>=1.21.0)", "mypy-boto3-organizations (>=1.21.0)", "mypy-boto3-outposts (>=1.21.0)", "mypy-boto3-panorama (>=1.21.0)", "mypy-boto3-personalize (>=1.21.0)", "mypy-boto3-personalize-events (>=1.21.0)", "mypy-boto3-personalize-runtime (>=1.21.0)", "mypy-boto3-pi (>=1.21.0)", "mypy-boto3-pinpoint (>=1.21.0)", "mypy-boto3-pinpoint-email (>=1.21.0)", "mypy-boto3-pinpoint-sms-voice (>=1.21.0)", "mypy-boto3-polly (>=1.21.0)", "mypy-boto3-pricing (>=1.21.0)", "mypy-boto3-proton (>=1.21.0)", "mypy-boto3-qldb (>=1.21.0)", "mypy-boto3-qldb-session (>=1.21.0)", "mypy-boto3-quicksight (>=1.21.0)", "mypy-boto3-ram (>=1.21.0)", "mypy-boto3-rbin (>=1.21.0)", "mypy-boto3-rds (>=1.21.0)", "mypy-boto3-rds-data (>=1.21.0)", "mypy-boto3-redshift (>=1.21.0)", "mypy-boto3-redshift-data (>=1.21.0)", "mypy-boto3-rekognition (>=1.21.0)", "mypy-boto3-resiliencehub (>=1.21.0)", "mypy-boto3-resource-groups (>=1.21.0)", "mypy-boto3-resourcegroupstaggingapi (>=1.21.0)", "mypy-boto3-robomaker (>=1.21.0)", "mypy-boto3-route53 (>=1.21.0)", "mypy-boto3-route53-recovery-cluster (>=1.21.0)", "mypy-boto3-route53-recovery-control-config (>=1.21.0)", "mypy-boto3-route53-recovery-readiness (>=1.21.0)", "mypy-boto3-route53domains (>=1.21.0)", "mypy-boto3-route53resolver (>=1.21.0)", "mypy-boto3-rum (>=1.21.0)", "mypy-boto3-s3 (>=1.21.0)", "mypy-boto3-s3control (>=1.21.0)", "mypy-boto3-s3outposts (>=1.21.0)", "mypy-boto3-sagemaker (>=1.21.0)", "mypy-boto3-sagemaker-a2i-runtime (>=1.21.0)", "mypy-boto3-sagemaker-edge (>=1.21.0)", "mypy-boto3-sagemaker-featurestore-runtime (>=1.21.0)", "mypy-boto3-sagemaker-runtime (>=1.21.0)", "mypy-boto3-savingsplans (>=1.21.0)", "mypy-boto3-schemas (>=1.21.0)", "mypy-boto3-sdb (>=1.21.0)", "mypy-boto3-secretsmanager (>=1.21.0)", "mypy-boto3-securityhub (>=1.21.0)", "mypy-boto3-serverlessrepo (>=1.21.0)", "mypy-boto3-service-quotas (>=1.21.0)", "mypy-boto3-servicecatalog (>=1.21.0)", "mypy-boto3-servicecatalog-appregistry (>=1.21.0)", "mypy-boto3-servicediscovery (>=1.21.0)", "mypy-boto3-ses (>=1.21.0)", "mypy-boto3-sesv2 (>=1.21.0)", "mypy-boto3-shield (>=1.21.0)", "mypy-boto3-signer (>=1.21.0)", "mypy-boto3-sms (>=1.21.0)", "mypy-boto3-sms-voice (>=1.21.0)", "mypy-boto3-snow-device-management (>=1.21.0)", "mypy-boto3-snowball (>=1.21.0)", "mypy-boto3-sns (>=1.21.0)", "mypy-boto3-sqs (>=1.21.0)", "mypy-boto3-ssm (>=1.21.0)", "mypy-boto3-ssm-contacts (>=1.21.0)", "mypy-boto3-ssm-incidents (>=1.21.0)", "mypy-boto3-sso (>=1.21.0)", "mypy-boto3-sso-admin (>=1.21.0)", "mypy-boto3-sso-oidc (>=1.21.0)", "mypy-boto3-stepfunctions (>=1.21.0)", "mypy-boto3-storagegateway (>=1.21.0)", "mypy-boto3-sts (>=1.21.0)", "mypy-boto3-support (>=1.21.0)", "mypy-boto3-swf (>=1.21.0)", "mypy-boto3-synthetics (>=1.21.0)", "mypy-boto3-textract (>=1.21.0)", "mypy-boto3-timestream-query (>=1.21.0)", "mypy-boto3-timestream-write (>=1.21.0)", "mypy-boto3-transcribe (>=1.21.0)", "mypy-boto3-transfer (>=1.21.0)", "mypy-boto3-translate (>=1.21.0)", "mypy-boto3-voice-id (>=1.21.0)", "mypy-boto3-waf (>=1.21.0)", "mypy-boto3-waf-regional (>=1.21.0)", "mypy-boto3-wafv2 (>=1.21.0)", "mypy-boto3-wellarchitected (>=1.21.0)", "mypy-boto3-wisdom (>=1.21.0)", "mypy-boto3-workdocs (>=1.21.0)", "mypy-boto3-worklink (>=1.21.0)", "mypy-boto3-workmail (>=1.21.0)", "mypy-boto3-workmailmessageflow (>=1.21.0)", "mypy-boto3-workspaces (>=1.21.0)", "mypy-boto3-workspaces-web (>=1.21.0)", "mypy-boto3-xray (>=1.21.0)"]
+amp = ["mypy-boto3-amp (>=1.21.0)"]
+amplify = ["mypy-boto3-amplify (>=1.21.0)"]
+amplifybackend = ["mypy-boto3-amplifybackend (>=1.21.0)"]
+amplifyuibuilder = ["mypy-boto3-amplifyuibuilder (>=1.21.0)"]
+apigateway = ["mypy-boto3-apigateway (>=1.21.0)"]
+apigatewaymanagementapi = ["mypy-boto3-apigatewaymanagementapi (>=1.21.0)"]
+apigatewayv2 = ["mypy-boto3-apigatewayv2 (>=1.21.0)"]
+appconfig = ["mypy-boto3-appconfig (>=1.21.0)"]
+appconfigdata = ["mypy-boto3-appconfigdata (>=1.21.0)"]
+appflow = ["mypy-boto3-appflow (>=1.21.0)"]
+appintegrations = ["mypy-boto3-appintegrations (>=1.21.0)"]
+application-autoscaling = ["mypy-boto3-application-autoscaling (>=1.21.0)"]
+application-insights = ["mypy-boto3-application-insights (>=1.21.0)"]
+applicationcostprofiler = ["mypy-boto3-applicationcostprofiler (>=1.21.0)"]
+appmesh = ["mypy-boto3-appmesh (>=1.21.0)"]
+apprunner = ["mypy-boto3-apprunner (>=1.21.0)"]
+appstream = ["mypy-boto3-appstream (>=1.21.0)"]
+appsync = ["mypy-boto3-appsync (>=1.21.0)"]
+athena = ["mypy-boto3-athena (>=1.21.0)"]
+auditmanager = ["mypy-boto3-auditmanager (>=1.21.0)"]
+autoscaling = ["mypy-boto3-autoscaling (>=1.21.0)"]
+autoscaling-plans = ["mypy-boto3-autoscaling-plans (>=1.21.0)"]
+backup = ["mypy-boto3-backup (>=1.21.0)"]
+backup-gateway = ["mypy-boto3-backup-gateway (>=1.21.0)"]
+batch = ["mypy-boto3-batch (>=1.21.0)"]
+braket = ["mypy-boto3-braket (>=1.21.0)"]
+budgets = ["mypy-boto3-budgets (>=1.21.0)"]
+ce = ["mypy-boto3-ce (>=1.21.0)"]
+chime = ["mypy-boto3-chime (>=1.21.0)"]
+chime-sdk-identity = ["mypy-boto3-chime-sdk-identity (>=1.21.0)"]
+chime-sdk-meetings = ["mypy-boto3-chime-sdk-meetings (>=1.21.0)"]
+chime-sdk-messaging = ["mypy-boto3-chime-sdk-messaging (>=1.21.0)"]
+cloud9 = ["mypy-boto3-cloud9 (>=1.21.0)"]
+cloudcontrol = ["mypy-boto3-cloudcontrol (>=1.21.0)"]
+clouddirectory = ["mypy-boto3-clouddirectory (>=1.21.0)"]
+cloudformation = ["mypy-boto3-cloudformation (>=1.21.0)"]
+cloudfront = ["mypy-boto3-cloudfront (>=1.21.0)"]
+cloudhsm = ["mypy-boto3-cloudhsm (>=1.21.0)"]
+cloudhsmv2 = ["mypy-boto3-cloudhsmv2 (>=1.21.0)"]
+cloudsearch = ["mypy-boto3-cloudsearch (>=1.21.0)"]
+cloudsearchdomain = ["mypy-boto3-cloudsearchdomain (>=1.21.0)"]
+cloudtrail = ["mypy-boto3-cloudtrail (>=1.21.0)"]
+cloudwatch = ["mypy-boto3-cloudwatch (>=1.21.0)"]
+codeartifact = ["mypy-boto3-codeartifact (>=1.21.0)"]
+codebuild = ["mypy-boto3-codebuild (>=1.21.0)"]
+codecommit = ["mypy-boto3-codecommit (>=1.21.0)"]
+codedeploy = ["mypy-boto3-codedeploy (>=1.21.0)"]
+codeguru-reviewer = ["mypy-boto3-codeguru-reviewer (>=1.21.0)"]
+codeguruprofiler = ["mypy-boto3-codeguruprofiler (>=1.21.0)"]
+codepipeline = ["mypy-boto3-codepipeline (>=1.21.0)"]
+codestar = ["mypy-boto3-codestar (>=1.21.0)"]
+codestar-connections = ["mypy-boto3-codestar-connections (>=1.21.0)"]
+codestar-notifications = ["mypy-boto3-codestar-notifications (>=1.21.0)"]
+cognito-identity = ["mypy-boto3-cognito-identity (>=1.21.0)"]
+cognito-idp = ["mypy-boto3-cognito-idp (>=1.21.0)"]
+cognito-sync = ["mypy-boto3-cognito-sync (>=1.21.0)"]
+comprehend = ["mypy-boto3-comprehend (>=1.21.0)"]
+comprehendmedical = ["mypy-boto3-comprehendmedical (>=1.21.0)"]
+compute-optimizer = ["mypy-boto3-compute-optimizer (>=1.21.0)"]
+config = ["mypy-boto3-config (>=1.21.0)"]
+connect = ["mypy-boto3-connect (>=1.21.0)"]
+connect-contact-lens = ["mypy-boto3-connect-contact-lens (>=1.21.0)"]
+connectparticipant = ["mypy-boto3-connectparticipant (>=1.21.0)"]
+cur = ["mypy-boto3-cur (>=1.21.0)"]
+customer-profiles = ["mypy-boto3-customer-profiles (>=1.21.0)"]
+databrew = ["mypy-boto3-databrew (>=1.21.0)"]
+dataexchange = ["mypy-boto3-dataexchange (>=1.21.0)"]
+datapipeline = ["mypy-boto3-datapipeline (>=1.21.0)"]
+datasync = ["mypy-boto3-datasync (>=1.21.0)"]
+dax = ["mypy-boto3-dax (>=1.21.0)"]
+detective = ["mypy-boto3-detective (>=1.21.0)"]
+devicefarm = ["mypy-boto3-devicefarm (>=1.21.0)"]
+devops-guru = ["mypy-boto3-devops-guru (>=1.21.0)"]
+directconnect = ["mypy-boto3-directconnect (>=1.21.0)"]
+discovery = ["mypy-boto3-discovery (>=1.21.0)"]
+dlm = ["mypy-boto3-dlm (>=1.21.0)"]
+dms = ["mypy-boto3-dms (>=1.21.0)"]
+docdb = ["mypy-boto3-docdb (>=1.21.0)"]
+drs = ["mypy-boto3-drs (>=1.21.0)"]
+ds = ["mypy-boto3-ds (>=1.21.0)"]
+dynamodb = ["mypy-boto3-dynamodb (>=1.21.0)"]
+dynamodbstreams = ["mypy-boto3-dynamodbstreams (>=1.21.0)"]
+ebs = ["mypy-boto3-ebs (>=1.21.0)"]
+ec2 = ["mypy-boto3-ec2 (>=1.21.0)"]
+ec2-instance-connect = ["mypy-boto3-ec2-instance-connect (>=1.21.0)"]
+ecr = ["mypy-boto3-ecr (>=1.21.0)"]
+ecr-public = ["mypy-boto3-ecr-public (>=1.21.0)"]
+ecs = ["mypy-boto3-ecs (>=1.21.0)"]
+efs = ["mypy-boto3-efs (>=1.21.0)"]
+eks = ["mypy-boto3-eks (>=1.21.0)"]
+elastic-inference = ["mypy-boto3-elastic-inference (>=1.21.0)"]
+elasticache = ["mypy-boto3-elasticache (>=1.21.0)"]
+elasticbeanstalk = ["mypy-boto3-elasticbeanstalk (>=1.21.0)"]
+elastictranscoder = ["mypy-boto3-elastictranscoder (>=1.21.0)"]
+elb = ["mypy-boto3-elb (>=1.21.0)"]
+elbv2 = ["mypy-boto3-elbv2 (>=1.21.0)"]
+emr = ["mypy-boto3-emr (>=1.21.0)"]
+emr-containers = ["mypy-boto3-emr-containers (>=1.21.0)"]
+es = ["mypy-boto3-es (>=1.21.0)"]
+essential = ["mypy-boto3-cloudformation (>=1.21.0)", "mypy-boto3-dynamodb (>=1.21.0)", "mypy-boto3-ec2 (>=1.21.0)", "mypy-boto3-lambda (>=1.21.0)", "mypy-boto3-rds (>=1.21.0)", "mypy-boto3-s3 (>=1.21.0)", "mypy-boto3-sqs (>=1.21.0)"]
+events = ["mypy-boto3-events (>=1.21.0)"]
+evidently = ["mypy-boto3-evidently (>=1.21.0)"]
+finspace = ["mypy-boto3-finspace (>=1.21.0)"]
+finspace-data = ["mypy-boto3-finspace-data (>=1.21.0)"]
+firehose = ["mypy-boto3-firehose (>=1.21.0)"]
+fis = ["mypy-boto3-fis (>=1.21.0)"]
+fms = ["mypy-boto3-fms (>=1.21.0)"]
+forecast = ["mypy-boto3-forecast (>=1.21.0)"]
+forecastquery = ["mypy-boto3-forecastquery (>=1.21.0)"]
+frauddetector = ["mypy-boto3-frauddetector (>=1.21.0)"]
+fsx = ["mypy-boto3-fsx (>=1.21.0)"]
+gamelift = ["mypy-boto3-gamelift (>=1.21.0)"]
+glacier = ["mypy-boto3-glacier (>=1.21.0)"]
+globalaccelerator = ["mypy-boto3-globalaccelerator (>=1.21.0)"]
+glue = ["mypy-boto3-glue (>=1.21.0)"]
+grafana = ["mypy-boto3-grafana (>=1.21.0)"]
+greengrass = ["mypy-boto3-greengrass (>=1.21.0)"]
+greengrassv2 = ["mypy-boto3-greengrassv2 (>=1.21.0)"]
+groundstation = ["mypy-boto3-groundstation (>=1.21.0)"]
+guardduty = ["mypy-boto3-guardduty (>=1.21.0)"]
+health = ["mypy-boto3-health (>=1.21.0)"]
+healthlake = ["mypy-boto3-healthlake (>=1.21.0)"]
+honeycode = ["mypy-boto3-honeycode (>=1.21.0)"]
+iam = ["mypy-boto3-iam (>=1.21.0)"]
+identitystore = ["mypy-boto3-identitystore (>=1.21.0)"]
+imagebuilder = ["mypy-boto3-imagebuilder (>=1.21.0)"]
+importexport = ["mypy-boto3-importexport (>=1.21.0)"]
+inspector = ["mypy-boto3-inspector (>=1.21.0)"]
+inspector2 = ["mypy-boto3-inspector2 (>=1.21.0)"]
+iot = ["mypy-boto3-iot (>=1.21.0)"]
+iot-data = ["mypy-boto3-iot-data (>=1.21.0)"]
+iot-jobs-data = ["mypy-boto3-iot-jobs-data (>=1.21.0)"]
+iot1click-devices = ["mypy-boto3-iot1click-devices (>=1.21.0)"]
+iot1click-projects = ["mypy-boto3-iot1click-projects (>=1.21.0)"]
+iotanalytics = ["mypy-boto3-iotanalytics (>=1.21.0)"]
+iotdeviceadvisor = ["mypy-boto3-iotdeviceadvisor (>=1.21.0)"]
+iotevents = ["mypy-boto3-iotevents (>=1.21.0)"]
+iotevents-data = ["mypy-boto3-iotevents-data (>=1.21.0)"]
+iotfleethub = ["mypy-boto3-iotfleethub (>=1.21.0)"]
+iotsecuretunneling = ["mypy-boto3-iotsecuretunneling (>=1.21.0)"]
+iotsitewise = ["mypy-boto3-iotsitewise (>=1.21.0)"]
+iotthingsgraph = ["mypy-boto3-iotthingsgraph (>=1.21.0)"]
+iottwinmaker = ["mypy-boto3-iottwinmaker (>=1.21.0)"]
+iotwireless = ["mypy-boto3-iotwireless (>=1.21.0)"]
+ivs = ["mypy-boto3-ivs (>=1.21.0)"]
+kafka = ["mypy-boto3-kafka (>=1.21.0)"]
+kafkaconnect = ["mypy-boto3-kafkaconnect (>=1.21.0)"]
+kendra = ["mypy-boto3-kendra (>=1.21.0)"]
+keyspaces = ["mypy-boto3-keyspaces (>=1.21.0)"]
+kinesis = ["mypy-boto3-kinesis (>=1.21.0)"]
+kinesis-video-archived-media = ["mypy-boto3-kinesis-video-archived-media (>=1.21.0)"]
+kinesis-video-media = ["mypy-boto3-kinesis-video-media (>=1.21.0)"]
+kinesis-video-signaling = ["mypy-boto3-kinesis-video-signaling (>=1.21.0)"]
+kinesisanalytics = ["mypy-boto3-kinesisanalytics (>=1.21.0)"]
+kinesisanalyticsv2 = ["mypy-boto3-kinesisanalyticsv2 (>=1.21.0)"]
+kinesisvideo = ["mypy-boto3-kinesisvideo (>=1.21.0)"]
+kms = ["mypy-boto3-kms (>=1.21.0)"]
+lakeformation = ["mypy-boto3-lakeformation (>=1.21.0)"]
+lambda = ["mypy-boto3-lambda (>=1.21.0)"]
+lex-models = ["mypy-boto3-lex-models (>=1.21.0)"]
+lex-runtime = ["mypy-boto3-lex-runtime (>=1.21.0)"]
+lexv2-models = ["mypy-boto3-lexv2-models (>=1.21.0)"]
+lexv2-runtime = ["mypy-boto3-lexv2-runtime (>=1.21.0)"]
+license-manager = ["mypy-boto3-license-manager (>=1.21.0)"]
+lightsail = ["mypy-boto3-lightsail (>=1.21.0)"]
+location = ["mypy-boto3-location (>=1.21.0)"]
+logs = ["mypy-boto3-logs (>=1.21.0)"]
+lookoutequipment = ["mypy-boto3-lookoutequipment (>=1.21.0)"]
+lookoutmetrics = ["mypy-boto3-lookoutmetrics (>=1.21.0)"]
+lookoutvision = ["mypy-boto3-lookoutvision (>=1.21.0)"]
+machinelearning = ["mypy-boto3-machinelearning (>=1.21.0)"]
+macie = ["mypy-boto3-macie (>=1.21.0)"]
+macie2 = ["mypy-boto3-macie2 (>=1.21.0)"]
+managedblockchain = ["mypy-boto3-managedblockchain (>=1.21.0)"]
+marketplace-catalog = ["mypy-boto3-marketplace-catalog (>=1.21.0)"]
+marketplace-entitlement = ["mypy-boto3-marketplace-entitlement (>=1.21.0)"]
+marketplacecommerceanalytics = ["mypy-boto3-marketplacecommerceanalytics (>=1.21.0)"]
+mediaconnect = ["mypy-boto3-mediaconnect (>=1.21.0)"]
+mediaconvert = ["mypy-boto3-mediaconvert (>=1.21.0)"]
+medialive = ["mypy-boto3-medialive (>=1.21.0)"]
+mediapackage = ["mypy-boto3-mediapackage (>=1.21.0)"]
+mediapackage-vod = ["mypy-boto3-mediapackage-vod (>=1.21.0)"]
+mediastore = ["mypy-boto3-mediastore (>=1.21.0)"]
+mediastore-data = ["mypy-boto3-mediastore-data (>=1.21.0)"]
+mediatailor = ["mypy-boto3-mediatailor (>=1.21.0)"]
+memorydb = ["mypy-boto3-memorydb (>=1.21.0)"]
+meteringmarketplace = ["mypy-boto3-meteringmarketplace (>=1.21.0)"]
+mgh = ["mypy-boto3-mgh (>=1.21.0)"]
+mgn = ["mypy-boto3-mgn (>=1.21.0)"]
+migration-hub-refactor-spaces = ["mypy-boto3-migration-hub-refactor-spaces (>=1.21.0)"]
+migrationhub-config = ["mypy-boto3-migrationhub-config (>=1.21.0)"]
+migrationhubstrategy = ["mypy-boto3-migrationhubstrategy (>=1.21.0)"]
+mobile = ["mypy-boto3-mobile (>=1.21.0)"]
+mq = ["mypy-boto3-mq (>=1.21.0)"]
+mturk = ["mypy-boto3-mturk (>=1.21.0)"]
+mwaa = ["mypy-boto3-mwaa (>=1.21.0)"]
+neptune = ["mypy-boto3-neptune (>=1.21.0)"]
+network-firewall = ["mypy-boto3-network-firewall (>=1.21.0)"]
+networkmanager = ["mypy-boto3-networkmanager (>=1.21.0)"]
+nimble = ["mypy-boto3-nimble (>=1.21.0)"]
+opensearch = ["mypy-boto3-opensearch (>=1.21.0)"]
+opsworks = ["mypy-boto3-opsworks (>=1.21.0)"]
+opsworkscm = ["mypy-boto3-opsworkscm (>=1.21.0)"]
+organizations = ["mypy-boto3-organizations (>=1.21.0)"]
+outposts = ["mypy-boto3-outposts (>=1.21.0)"]
+panorama = ["mypy-boto3-panorama (>=1.21.0)"]
+personalize = ["mypy-boto3-personalize (>=1.21.0)"]
+personalize-events = ["mypy-boto3-personalize-events (>=1.21.0)"]
+personalize-runtime = ["mypy-boto3-personalize-runtime (>=1.21.0)"]
+pi = ["mypy-boto3-pi (>=1.21.0)"]
+pinpoint = ["mypy-boto3-pinpoint (>=1.21.0)"]
+pinpoint-email = ["mypy-boto3-pinpoint-email (>=1.21.0)"]
+pinpoint-sms-voice = ["mypy-boto3-pinpoint-sms-voice (>=1.21.0)"]
+polly = ["mypy-boto3-polly (>=1.21.0)"]
+pricing = ["mypy-boto3-pricing (>=1.21.0)"]
+proton = ["mypy-boto3-proton (>=1.21.0)"]
+qldb = ["mypy-boto3-qldb (>=1.21.0)"]
+qldb-session = ["mypy-boto3-qldb-session (>=1.21.0)"]
+quicksight = ["mypy-boto3-quicksight (>=1.21.0)"]
+ram = ["mypy-boto3-ram (>=1.21.0)"]
+rbin = ["mypy-boto3-rbin (>=1.21.0)"]
+rds = ["mypy-boto3-rds (>=1.21.0)"]
+rds-data = ["mypy-boto3-rds-data (>=1.21.0)"]
+redshift = ["mypy-boto3-redshift (>=1.21.0)"]
+redshift-data = ["mypy-boto3-redshift-data (>=1.21.0)"]
+rekognition = ["mypy-boto3-rekognition (>=1.21.0)"]
+resiliencehub = ["mypy-boto3-resiliencehub (>=1.21.0)"]
+resource-groups = ["mypy-boto3-resource-groups (>=1.21.0)"]
+resourcegroupstaggingapi = ["mypy-boto3-resourcegroupstaggingapi (>=1.21.0)"]
+robomaker = ["mypy-boto3-robomaker (>=1.21.0)"]
+route53 = ["mypy-boto3-route53 (>=1.21.0)"]
+route53-recovery-cluster = ["mypy-boto3-route53-recovery-cluster (>=1.21.0)"]
+route53-recovery-control-config = ["mypy-boto3-route53-recovery-control-config (>=1.21.0)"]
+route53-recovery-readiness = ["mypy-boto3-route53-recovery-readiness (>=1.21.0)"]
+route53domains = ["mypy-boto3-route53domains (>=1.21.0)"]
+route53resolver = ["mypy-boto3-route53resolver (>=1.21.0)"]
+rum = ["mypy-boto3-rum (>=1.21.0)"]
+s3 = ["mypy-boto3-s3 (>=1.21.0)"]
+s3control = ["mypy-boto3-s3control (>=1.21.0)"]
+s3outposts = ["mypy-boto3-s3outposts (>=1.21.0)"]
+sagemaker = ["mypy-boto3-sagemaker (>=1.21.0)"]
+sagemaker-a2i-runtime = ["mypy-boto3-sagemaker-a2i-runtime (>=1.21.0)"]
+sagemaker-edge = ["mypy-boto3-sagemaker-edge (>=1.21.0)"]
+sagemaker-featurestore-runtime = ["mypy-boto3-sagemaker-featurestore-runtime (>=1.21.0)"]
+sagemaker-runtime = ["mypy-boto3-sagemaker-runtime (>=1.21.0)"]
+savingsplans = ["mypy-boto3-savingsplans (>=1.21.0)"]
+schemas = ["mypy-boto3-schemas (>=1.21.0)"]
+sdb = ["mypy-boto3-sdb (>=1.21.0)"]
+secretsmanager = ["mypy-boto3-secretsmanager (>=1.21.0)"]
+securityhub = ["mypy-boto3-securityhub (>=1.21.0)"]
+serverlessrepo = ["mypy-boto3-serverlessrepo (>=1.21.0)"]
+service-quotas = ["mypy-boto3-service-quotas (>=1.21.0)"]
+servicecatalog = ["mypy-boto3-servicecatalog (>=1.21.0)"]
+servicecatalog-appregistry = ["mypy-boto3-servicecatalog-appregistry (>=1.21.0)"]
+servicediscovery = ["mypy-boto3-servicediscovery (>=1.21.0)"]
+ses = ["mypy-boto3-ses (>=1.21.0)"]
+sesv2 = ["mypy-boto3-sesv2 (>=1.21.0)"]
+shield = ["mypy-boto3-shield (>=1.21.0)"]
+signer = ["mypy-boto3-signer (>=1.21.0)"]
+sms = ["mypy-boto3-sms (>=1.21.0)"]
+sms-voice = ["mypy-boto3-sms-voice (>=1.21.0)"]
+snow-device-management = ["mypy-boto3-snow-device-management (>=1.21.0)"]
+snowball = ["mypy-boto3-snowball (>=1.21.0)"]
+sns = ["mypy-boto3-sns (>=1.21.0)"]
+sqs = ["mypy-boto3-sqs (>=1.21.0)"]
+ssm = ["mypy-boto3-ssm (>=1.21.0)"]
+ssm-contacts = ["mypy-boto3-ssm-contacts (>=1.21.0)"]
+ssm-incidents = ["mypy-boto3-ssm-incidents (>=1.21.0)"]
+sso = ["mypy-boto3-sso (>=1.21.0)"]
+sso-admin = ["mypy-boto3-sso-admin (>=1.21.0)"]
+sso-oidc = ["mypy-boto3-sso-oidc (>=1.21.0)"]
+stepfunctions = ["mypy-boto3-stepfunctions (>=1.21.0)"]
+storagegateway = ["mypy-boto3-storagegateway (>=1.21.0)"]
+sts = ["mypy-boto3-sts (>=1.21.0)"]
+support = ["mypy-boto3-support (>=1.21.0)"]
+swf = ["mypy-boto3-swf (>=1.21.0)"]
+synthetics = ["mypy-boto3-synthetics (>=1.21.0)"]
+textract = ["mypy-boto3-textract (>=1.21.0)"]
+timestream-query = ["mypy-boto3-timestream-query (>=1.21.0)"]
+timestream-write = ["mypy-boto3-timestream-write (>=1.21.0)"]
+transcribe = ["mypy-boto3-transcribe (>=1.21.0)"]
+transfer = ["mypy-boto3-transfer (>=1.21.0)"]
+translate = ["mypy-boto3-translate (>=1.21.0)"]
+voice-id = ["mypy-boto3-voice-id (>=1.21.0)"]
+waf = ["mypy-boto3-waf (>=1.21.0)"]
+waf-regional = ["mypy-boto3-waf-regional (>=1.21.0)"]
+wafv2 = ["mypy-boto3-wafv2 (>=1.21.0)"]
+wellarchitected = ["mypy-boto3-wellarchitected (>=1.21.0)"]
+wisdom = ["mypy-boto3-wisdom (>=1.21.0)"]
+workdocs = ["mypy-boto3-workdocs (>=1.21.0)"]
+worklink = ["mypy-boto3-worklink (>=1.21.0)"]
+workmail = ["mypy-boto3-workmail (>=1.21.0)"]
+workmailmessageflow = ["mypy-boto3-workmailmessageflow (>=1.21.0)"]
+workspaces = ["mypy-boto3-workspaces (>=1.21.0)"]
+workspaces-web = ["mypy-boto3-workspaces-web (>=1.21.0)"]
+xray = ["mypy-boto3-xray (>=1.21.0)"]
+
+[[package]]
 name = "botocore"
-version = "1.24.2"
+version = "1.24.13"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -74,6 +393,17 @@ urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
 crt = ["awscrt (==0.12.5)"]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.24.13"
+description = "Type annotations for botocore 1.24.13 generated with mypy-boto3-builder 7.3.0"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "certifi"
@@ -115,7 +445,7 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.3"
+version = "8.0.4"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
@@ -197,7 +527,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.1"
+version = "4.11.2"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -208,7 +538,7 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
@@ -303,6 +633,39 @@ s3 = ["PyYAML (>=5.1)"]
 server = ["PyYAML (>=5.1)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "ecdsa (!=0.15)", "docker (>=2.5.1)", "graphql-core", "jsondiff (>=1.1.2)", "aws-xray-sdk (>=0.93,!=0.96)", "idna (>=2.5,<4)", "cfn-lint (>=0.4.0)", "sshpubkeys (>=3.1.0)", "setuptools", "flask", "flask-cors"]
 ssm = ["PyYAML (>=5.1)", "dataclasses"]
 xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
+
+[[package]]
+name = "mypy-boto3-cloudformation"
+version = "1.21.0"
+description = "Type annotations for boto3.CloudFormation 1.21.0 service generated by mypy-boto3-builder 7.0.4"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
+
+[[package]]
+name = "mypy-boto3-codecommit"
+version = "1.21.0"
+description = "Type annotations for boto3.CodeCommit 1.21.0 service generated by mypy-boto3-builder 7.0.4"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
+
+[[package]]
+name = "mypy-boto3-sts"
+version = "1.21.13"
+description = "Type annotations for boto3.STS 1.21.13 service generated with mypy-boto3-builder 7.3.0"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "packaging"
@@ -400,7 +763,7 @@ six = ">=1.5"
 
 [[package]]
 name = "python-slugify"
-version = "6.0.1"
+version = "6.1.1"
 description = "A Python slugify application that also handles Unicode"
 category = "main"
 optional = false
@@ -471,7 +834,7 @@ tests = ["pytest (>=4.6)", "coverage (>=6.0.0)", "pytest-cov", "pytest-localserv
 
 [[package]]
 name = "s3transfer"
-version = "0.5.1"
+version = "0.5.2"
 description = "An Amazon S3 Transfer Manager"
 category = "main"
 optional = false
@@ -530,7 +893,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "websocket-client"
-version = "1.2.3"
+version = "1.3.1"
 description = "WebSocket client for Python with low level API options"
 category = "dev"
 optional = false
@@ -575,7 +938,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <3.11"
-content-hash = "82d1d3dde09c4aa10f2ad450770d587f39bbdc15d26396dfd7fded8352a1ef84"
+content-hash = "a36ba2cdd3700cced91e36e4425e9a0625bf8b87fd9f31ccee1c6c4fd3f3b2f0"
 
 [metadata.files]
 arrow = [
@@ -595,12 +958,20 @@ binaryornot = [
     {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
 ]
 boto3 = [
-    {file = "boto3-1.21.2-py3-none-any.whl", hash = "sha256:50de4ae3dc9cbc3065b184247580160540273b25e7eaf72cdc18b979294a1b54"},
-    {file = "boto3-1.21.2.tar.gz", hash = "sha256:e46133e44d5600e3de6739c60af2cc47d23742234df149aab3ccff4f1edec64d"},
+    {file = "boto3-1.21.13-py3-none-any.whl", hash = "sha256:e17d994d222162dac02ec32fde6ae910d819ebf239a94dddcee47def2c82b9c9"},
+    {file = "boto3-1.21.13.tar.gz", hash = "sha256:16fae86d0c4993fd5112128bb4622a879f02363bccd045153cc0bbd7722cc9a5"},
+]
+boto3-stubs-lite = [
+    {file = "boto3-stubs-lite-1.21.13.tar.gz", hash = "sha256:d57aadd66b8863eb82b71ef85b346b979e32c0843d490537ecdea12fe9e10aa4"},
+    {file = "boto3_stubs_lite-1.21.13-py3-none-any.whl", hash = "sha256:a333855642fe38bad1d8245495a622c7c0b3c3c2253788014ab0558e42f830c1"},
 ]
 botocore = [
-    {file = "botocore-1.24.2-py3-none-any.whl", hash = "sha256:d1547d0bd8428df2dc1ad95b227e271914bb01f8edbd16a45766465c2090bc9b"},
-    {file = "botocore-1.24.2.tar.gz", hash = "sha256:c017dd174285a07db4e1b844750c43550c1f51e8256e722f1e69030c4f6c78f1"},
+    {file = "botocore-1.24.13-py3-none-any.whl", hash = "sha256:7b166096f9413b41caf7cc6f4edfd5b3c3ab9d7c61eb120a649e69485c98131a"},
+    {file = "botocore-1.24.13.tar.gz", hash = "sha256:46e51f56f1c5784e4245e036503635fa71b722775657b6e1acf21ec5b906974c"},
+]
+botocore-stubs = [
+    {file = "botocore-stubs-1.24.13.tar.gz", hash = "sha256:eddcb423f18817cad8f4fcba4db8f24ebb21f16a5c0e28e09771099edb47fcce"},
+    {file = "botocore_stubs-1.24.13-py3-none-any.whl", hash = "sha256:d172f4dde2df15c90bb6926801fe8cc6fad4d91d094faf35c34f69b8203d2b57"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -667,8 +1038,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
-    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -709,8 +1080,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.1-py3-none-any.whl", hash = "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"},
-    {file = "importlib_metadata-4.11.1.tar.gz", hash = "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c"},
+    {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
+    {file = "importlib_metadata-4.11.2.tar.gz", hash = "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -774,6 +1145,18 @@ moto = [
     {file = "moto-2.3.2-py2.py3-none-any.whl", hash = "sha256:0c29f5813d4db69b2f99c5538909a5aba0ba1cb91a74c19eddd9bfdc39ed2ff3"},
     {file = "moto-2.3.2.tar.gz", hash = "sha256:eaaed229742adbd1387383d113350ecd9222fc1e8f5611a9395a058c1eee4377"},
 ]
+mypy-boto3-cloudformation = [
+    {file = "mypy-boto3-cloudformation-1.21.0.tar.gz", hash = "sha256:f4eae0189897a060646d95f1c6e4644081d961b95c007dd1c1fbd3a0fa21616f"},
+    {file = "mypy_boto3_cloudformation-1.21.0-py3-none-any.whl", hash = "sha256:8c138380e9ccd6fa5ac6eb5c7f8a8c5f77005492cb26ca6b5b4fe19f2f199162"},
+]
+mypy-boto3-codecommit = [
+    {file = "mypy-boto3-codecommit-1.21.0.tar.gz", hash = "sha256:ed1261e36a15d75b1958e6809e268ad24de47b8c18983e483214aaef9f96ebfe"},
+    {file = "mypy_boto3_codecommit-1.21.0-py3-none-any.whl", hash = "sha256:ac438d5c79c112cd8ab70478afb8d1fd7917e6d1af5961a0f0ed1f0668a37064"},
+]
+mypy-boto3-sts = [
+    {file = "mypy-boto3-sts-1.21.13.tar.gz", hash = "sha256:b62d9f597826ba4668f9f3500dd6c74b71f55510de7f69d59df76a9ed4bc16c6"},
+    {file = "mypy_boto3_sts-1.21.13-py3-none-any.whl", hash = "sha256:452586399235f82d90b201a62a7c4a045d51eda34fb721f795a7f24c08b4c0e1"},
+]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -807,8 +1190,8 @@ python-dateutil = [
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 python-slugify = [
-    {file = "python-slugify-6.0.1.tar.gz", hash = "sha256:ba72aa9d9f0514c0c3dd4430442f698ccc27a24d19630473663a71e3ec606bc1"},
-    {file = "python_slugify-6.0.1-py2.py3-none-any.whl", hash = "sha256:89eec682c5180ba64811c9906a28184bbcc0a35792ba1bda3b5c2ab0cb2d0f67"},
+    {file = "python-slugify-6.1.1.tar.gz", hash = "sha256:00003397f4e31414e922ce567b3a4da28cf1436a53d332c9aeeb51c7d8c469fd"},
+    {file = "python_slugify-6.1.1-py2.py3-none-any.whl", hash = "sha256:8c0016b2d74503eb64761821612d58fcfc729493634b1eb0575d8f5b4aa1fbcf"},
 ]
 pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
@@ -868,8 +1251,8 @@ responses = [
     {file = "responses-0.18.0.tar.gz", hash = "sha256:380cad4c1c1dc942e5e8a8eaae0b4d4edf708f4f010db8b7bcfafad1fcd254ff"},
 ]
 s3transfer = [
-    {file = "s3transfer-0.5.1-py3-none-any.whl", hash = "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f"},
-    {file = "s3transfer-0.5.1.tar.gz", hash = "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a"},
+    {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},
+    {file = "s3transfer-0.5.2.tar.gz", hash = "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -892,8 +1275,8 @@ urllib3 = [
     {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
 websocket-client = [
-    {file = "websocket-client-1.2.3.tar.gz", hash = "sha256:1315816c0acc508997eb3ae03b9d3ff619c9d12d544c9a9b553704b1cc4f6af5"},
-    {file = "websocket_client-1.2.3-py3-none-any.whl", hash = "sha256:2eed4cc58e4d65613ed6114af2f380f7910ff416fc8c46947f6e76b6815f56c0"},
+    {file = "websocket-client-1.3.1.tar.gz", hash = "sha256:6278a75065395418283f887de7c3beafb3aa68dada5cacbe4b214e8d26da499b"},
+    {file = "websocket_client-1.3.1-py3-none-any.whl", hash = "sha256:074e2ed575e7c822fc0940d31c3ac9bb2b1142c303eafcf3e304e6ce035522e8"},
 ]
 werkzeug = [
     {file = "Werkzeug-2.0.3-py3-none-any.whl", hash = "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8"},

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -44,6 +44,8 @@ docker = "^5.0.0"
 moto = "^2.2.12"
 pytest = "^6.2.5"
 PyYAML = "^5.4.1"
+typing-extensions = "^4.1.1"
+boto3-stubs-lite = {version = "*", extras = ["codecommit", "cloudformation", "sts"]}
 
 [tool.poetry.scripts]
 ddk = "aws_ddk.__main__:main"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -44,8 +44,6 @@ docker = "^5.0.0"
 moto = "^2.2.12"
 pytest = "^6.2.5"
 PyYAML = "^5.4.1"
-typing-extensions = "^4.1.1"
-boto3-stubs-lite = {version = "*", extras = ["codecommit", "cloudformation", "sts"]}
 
 [tool.poetry.scripts]
 ddk = "aws_ddk.__main__:main"

--- a/poetry.lock
+++ b/poetry.lock
@@ -57,14 +57,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.21.1"
+version = "1.21.14"
 description = "The AWS SDK for Python"
 category = "dev"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.24.1,<1.25.0"
+botocore = ">=1.24.14,<1.25.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -72,8 +72,327 @@ s3transfer = ">=0.5.0,<0.6.0"
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
+name = "boto3-stubs-lite"
+version = "1.21.14"
+description = "Type annotations for boto3 1.21.14 generated with mypy-boto3-builder 7.3.0"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+botocore-stubs = "*"
+mypy-boto3-cloudformation = {version = ">=1.21.0", optional = true, markers = "extra == \"cloudformation\""}
+mypy-boto3-codecommit = {version = ">=1.21.0", optional = true, markers = "extra == \"codecommit\""}
+mypy-boto3-sts = {version = ">=1.21.0", optional = true, markers = "extra == \"sts\""}
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
+
+[package.extras]
+accessanalyzer = ["mypy-boto3-accessanalyzer (>=1.21.0)"]
+account = ["mypy-boto3-account (>=1.21.0)"]
+acm = ["mypy-boto3-acm (>=1.21.0)"]
+acm-pca = ["mypy-boto3-acm-pca (>=1.21.0)"]
+alexaforbusiness = ["mypy-boto3-alexaforbusiness (>=1.21.0)"]
+all = ["mypy-boto3-accessanalyzer (>=1.21.0)", "mypy-boto3-account (>=1.21.0)", "mypy-boto3-acm (>=1.21.0)", "mypy-boto3-acm-pca (>=1.21.0)", "mypy-boto3-alexaforbusiness (>=1.21.0)", "mypy-boto3-amp (>=1.21.0)", "mypy-boto3-amplify (>=1.21.0)", "mypy-boto3-amplifybackend (>=1.21.0)", "mypy-boto3-amplifyuibuilder (>=1.21.0)", "mypy-boto3-apigateway (>=1.21.0)", "mypy-boto3-apigatewaymanagementapi (>=1.21.0)", "mypy-boto3-apigatewayv2 (>=1.21.0)", "mypy-boto3-appconfig (>=1.21.0)", "mypy-boto3-appconfigdata (>=1.21.0)", "mypy-boto3-appflow (>=1.21.0)", "mypy-boto3-appintegrations (>=1.21.0)", "mypy-boto3-application-autoscaling (>=1.21.0)", "mypy-boto3-application-insights (>=1.21.0)", "mypy-boto3-applicationcostprofiler (>=1.21.0)", "mypy-boto3-appmesh (>=1.21.0)", "mypy-boto3-apprunner (>=1.21.0)", "mypy-boto3-appstream (>=1.21.0)", "mypy-boto3-appsync (>=1.21.0)", "mypy-boto3-athena (>=1.21.0)", "mypy-boto3-auditmanager (>=1.21.0)", "mypy-boto3-autoscaling (>=1.21.0)", "mypy-boto3-autoscaling-plans (>=1.21.0)", "mypy-boto3-backup (>=1.21.0)", "mypy-boto3-backup-gateway (>=1.21.0)", "mypy-boto3-batch (>=1.21.0)", "mypy-boto3-braket (>=1.21.0)", "mypy-boto3-budgets (>=1.21.0)", "mypy-boto3-ce (>=1.21.0)", "mypy-boto3-chime (>=1.21.0)", "mypy-boto3-chime-sdk-identity (>=1.21.0)", "mypy-boto3-chime-sdk-meetings (>=1.21.0)", "mypy-boto3-chime-sdk-messaging (>=1.21.0)", "mypy-boto3-cloud9 (>=1.21.0)", "mypy-boto3-cloudcontrol (>=1.21.0)", "mypy-boto3-clouddirectory (>=1.21.0)", "mypy-boto3-cloudformation (>=1.21.0)", "mypy-boto3-cloudfront (>=1.21.0)", "mypy-boto3-cloudhsm (>=1.21.0)", "mypy-boto3-cloudhsmv2 (>=1.21.0)", "mypy-boto3-cloudsearch (>=1.21.0)", "mypy-boto3-cloudsearchdomain (>=1.21.0)", "mypy-boto3-cloudtrail (>=1.21.0)", "mypy-boto3-cloudwatch (>=1.21.0)", "mypy-boto3-codeartifact (>=1.21.0)", "mypy-boto3-codebuild (>=1.21.0)", "mypy-boto3-codecommit (>=1.21.0)", "mypy-boto3-codedeploy (>=1.21.0)", "mypy-boto3-codeguru-reviewer (>=1.21.0)", "mypy-boto3-codeguruprofiler (>=1.21.0)", "mypy-boto3-codepipeline (>=1.21.0)", "mypy-boto3-codestar (>=1.21.0)", "mypy-boto3-codestar-connections (>=1.21.0)", "mypy-boto3-codestar-notifications (>=1.21.0)", "mypy-boto3-cognito-identity (>=1.21.0)", "mypy-boto3-cognito-idp (>=1.21.0)", "mypy-boto3-cognito-sync (>=1.21.0)", "mypy-boto3-comprehend (>=1.21.0)", "mypy-boto3-comprehendmedical (>=1.21.0)", "mypy-boto3-compute-optimizer (>=1.21.0)", "mypy-boto3-config (>=1.21.0)", "mypy-boto3-connect (>=1.21.0)", "mypy-boto3-connect-contact-lens (>=1.21.0)", "mypy-boto3-connectparticipant (>=1.21.0)", "mypy-boto3-cur (>=1.21.0)", "mypy-boto3-customer-profiles (>=1.21.0)", "mypy-boto3-databrew (>=1.21.0)", "mypy-boto3-dataexchange (>=1.21.0)", "mypy-boto3-datapipeline (>=1.21.0)", "mypy-boto3-datasync (>=1.21.0)", "mypy-boto3-dax (>=1.21.0)", "mypy-boto3-detective (>=1.21.0)", "mypy-boto3-devicefarm (>=1.21.0)", "mypy-boto3-devops-guru (>=1.21.0)", "mypy-boto3-directconnect (>=1.21.0)", "mypy-boto3-discovery (>=1.21.0)", "mypy-boto3-dlm (>=1.21.0)", "mypy-boto3-dms (>=1.21.0)", "mypy-boto3-docdb (>=1.21.0)", "mypy-boto3-drs (>=1.21.0)", "mypy-boto3-ds (>=1.21.0)", "mypy-boto3-dynamodb (>=1.21.0)", "mypy-boto3-dynamodbstreams (>=1.21.0)", "mypy-boto3-ebs (>=1.21.0)", "mypy-boto3-ec2 (>=1.21.0)", "mypy-boto3-ec2-instance-connect (>=1.21.0)", "mypy-boto3-ecr (>=1.21.0)", "mypy-boto3-ecr-public (>=1.21.0)", "mypy-boto3-ecs (>=1.21.0)", "mypy-boto3-efs (>=1.21.0)", "mypy-boto3-eks (>=1.21.0)", "mypy-boto3-elastic-inference (>=1.21.0)", "mypy-boto3-elasticache (>=1.21.0)", "mypy-boto3-elasticbeanstalk (>=1.21.0)", "mypy-boto3-elastictranscoder (>=1.21.0)", "mypy-boto3-elb (>=1.21.0)", "mypy-boto3-elbv2 (>=1.21.0)", "mypy-boto3-emr (>=1.21.0)", "mypy-boto3-emr-containers (>=1.21.0)", "mypy-boto3-es (>=1.21.0)", "mypy-boto3-events (>=1.21.0)", "mypy-boto3-evidently (>=1.21.0)", "mypy-boto3-finspace (>=1.21.0)", "mypy-boto3-finspace-data (>=1.21.0)", "mypy-boto3-firehose (>=1.21.0)", "mypy-boto3-fis (>=1.21.0)", "mypy-boto3-fms (>=1.21.0)", "mypy-boto3-forecast (>=1.21.0)", "mypy-boto3-forecastquery (>=1.21.0)", "mypy-boto3-frauddetector (>=1.21.0)", "mypy-boto3-fsx (>=1.21.0)", "mypy-boto3-gamelift (>=1.21.0)", "mypy-boto3-glacier (>=1.21.0)", "mypy-boto3-globalaccelerator (>=1.21.0)", "mypy-boto3-glue (>=1.21.0)", "mypy-boto3-grafana (>=1.21.0)", "mypy-boto3-greengrass (>=1.21.0)", "mypy-boto3-greengrassv2 (>=1.21.0)", "mypy-boto3-groundstation (>=1.21.0)", "mypy-boto3-guardduty (>=1.21.0)", "mypy-boto3-health (>=1.21.0)", "mypy-boto3-healthlake (>=1.21.0)", "mypy-boto3-honeycode (>=1.21.0)", "mypy-boto3-iam (>=1.21.0)", "mypy-boto3-identitystore (>=1.21.0)", "mypy-boto3-imagebuilder (>=1.21.0)", "mypy-boto3-importexport (>=1.21.0)", "mypy-boto3-inspector (>=1.21.0)", "mypy-boto3-inspector2 (>=1.21.0)", "mypy-boto3-iot (>=1.21.0)", "mypy-boto3-iot-data (>=1.21.0)", "mypy-boto3-iot-jobs-data (>=1.21.0)", "mypy-boto3-iot1click-devices (>=1.21.0)", "mypy-boto3-iot1click-projects (>=1.21.0)", "mypy-boto3-iotanalytics (>=1.21.0)", "mypy-boto3-iotdeviceadvisor (>=1.21.0)", "mypy-boto3-iotevents (>=1.21.0)", "mypy-boto3-iotevents-data (>=1.21.0)", "mypy-boto3-iotfleethub (>=1.21.0)", "mypy-boto3-iotsecuretunneling (>=1.21.0)", "mypy-boto3-iotsitewise (>=1.21.0)", "mypy-boto3-iotthingsgraph (>=1.21.0)", "mypy-boto3-iottwinmaker (>=1.21.0)", "mypy-boto3-iotwireless (>=1.21.0)", "mypy-boto3-ivs (>=1.21.0)", "mypy-boto3-kafka (>=1.21.0)", "mypy-boto3-kafkaconnect (>=1.21.0)", "mypy-boto3-kendra (>=1.21.0)", "mypy-boto3-keyspaces (>=1.21.0)", "mypy-boto3-kinesis (>=1.21.0)", "mypy-boto3-kinesis-video-archived-media (>=1.21.0)", "mypy-boto3-kinesis-video-media (>=1.21.0)", "mypy-boto3-kinesis-video-signaling (>=1.21.0)", "mypy-boto3-kinesisanalytics (>=1.21.0)", "mypy-boto3-kinesisanalyticsv2 (>=1.21.0)", "mypy-boto3-kinesisvideo (>=1.21.0)", "mypy-boto3-kms (>=1.21.0)", "mypy-boto3-lakeformation (>=1.21.0)", "mypy-boto3-lambda (>=1.21.0)", "mypy-boto3-lex-models (>=1.21.0)", "mypy-boto3-lex-runtime (>=1.21.0)", "mypy-boto3-lexv2-models (>=1.21.0)", "mypy-boto3-lexv2-runtime (>=1.21.0)", "mypy-boto3-license-manager (>=1.21.0)", "mypy-boto3-lightsail (>=1.21.0)", "mypy-boto3-location (>=1.21.0)", "mypy-boto3-logs (>=1.21.0)", "mypy-boto3-lookoutequipment (>=1.21.0)", "mypy-boto3-lookoutmetrics (>=1.21.0)", "mypy-boto3-lookoutvision (>=1.21.0)", "mypy-boto3-machinelearning (>=1.21.0)", "mypy-boto3-macie (>=1.21.0)", "mypy-boto3-macie2 (>=1.21.0)", "mypy-boto3-managedblockchain (>=1.21.0)", "mypy-boto3-marketplace-catalog (>=1.21.0)", "mypy-boto3-marketplace-entitlement (>=1.21.0)", "mypy-boto3-marketplacecommerceanalytics (>=1.21.0)", "mypy-boto3-mediaconnect (>=1.21.0)", "mypy-boto3-mediaconvert (>=1.21.0)", "mypy-boto3-medialive (>=1.21.0)", "mypy-boto3-mediapackage (>=1.21.0)", "mypy-boto3-mediapackage-vod (>=1.21.0)", "mypy-boto3-mediastore (>=1.21.0)", "mypy-boto3-mediastore-data (>=1.21.0)", "mypy-boto3-mediatailor (>=1.21.0)", "mypy-boto3-memorydb (>=1.21.0)", "mypy-boto3-meteringmarketplace (>=1.21.0)", "mypy-boto3-mgh (>=1.21.0)", "mypy-boto3-mgn (>=1.21.0)", "mypy-boto3-migration-hub-refactor-spaces (>=1.21.0)", "mypy-boto3-migrationhub-config (>=1.21.0)", "mypy-boto3-migrationhubstrategy (>=1.21.0)", "mypy-boto3-mobile (>=1.21.0)", "mypy-boto3-mq (>=1.21.0)", "mypy-boto3-mturk (>=1.21.0)", "mypy-boto3-mwaa (>=1.21.0)", "mypy-boto3-neptune (>=1.21.0)", "mypy-boto3-network-firewall (>=1.21.0)", "mypy-boto3-networkmanager (>=1.21.0)", "mypy-boto3-nimble (>=1.21.0)", "mypy-boto3-opensearch (>=1.21.0)", "mypy-boto3-opsworks (>=1.21.0)", "mypy-boto3-opsworkscm (>=1.21.0)", "mypy-boto3-organizations (>=1.21.0)", "mypy-boto3-outposts (>=1.21.0)", "mypy-boto3-panorama (>=1.21.0)", "mypy-boto3-personalize (>=1.21.0)", "mypy-boto3-personalize-events (>=1.21.0)", "mypy-boto3-personalize-runtime (>=1.21.0)", "mypy-boto3-pi (>=1.21.0)", "mypy-boto3-pinpoint (>=1.21.0)", "mypy-boto3-pinpoint-email (>=1.21.0)", "mypy-boto3-pinpoint-sms-voice (>=1.21.0)", "mypy-boto3-polly (>=1.21.0)", "mypy-boto3-pricing (>=1.21.0)", "mypy-boto3-proton (>=1.21.0)", "mypy-boto3-qldb (>=1.21.0)", "mypy-boto3-qldb-session (>=1.21.0)", "mypy-boto3-quicksight (>=1.21.0)", "mypy-boto3-ram (>=1.21.0)", "mypy-boto3-rbin (>=1.21.0)", "mypy-boto3-rds (>=1.21.0)", "mypy-boto3-rds-data (>=1.21.0)", "mypy-boto3-redshift (>=1.21.0)", "mypy-boto3-redshift-data (>=1.21.0)", "mypy-boto3-rekognition (>=1.21.0)", "mypy-boto3-resiliencehub (>=1.21.0)", "mypy-boto3-resource-groups (>=1.21.0)", "mypy-boto3-resourcegroupstaggingapi (>=1.21.0)", "mypy-boto3-robomaker (>=1.21.0)", "mypy-boto3-route53 (>=1.21.0)", "mypy-boto3-route53-recovery-cluster (>=1.21.0)", "mypy-boto3-route53-recovery-control-config (>=1.21.0)", "mypy-boto3-route53-recovery-readiness (>=1.21.0)", "mypy-boto3-route53domains (>=1.21.0)", "mypy-boto3-route53resolver (>=1.21.0)", "mypy-boto3-rum (>=1.21.0)", "mypy-boto3-s3 (>=1.21.0)", "mypy-boto3-s3control (>=1.21.0)", "mypy-boto3-s3outposts (>=1.21.0)", "mypy-boto3-sagemaker (>=1.21.0)", "mypy-boto3-sagemaker-a2i-runtime (>=1.21.0)", "mypy-boto3-sagemaker-edge (>=1.21.0)", "mypy-boto3-sagemaker-featurestore-runtime (>=1.21.0)", "mypy-boto3-sagemaker-runtime (>=1.21.0)", "mypy-boto3-savingsplans (>=1.21.0)", "mypy-boto3-schemas (>=1.21.0)", "mypy-boto3-sdb (>=1.21.0)", "mypy-boto3-secretsmanager (>=1.21.0)", "mypy-boto3-securityhub (>=1.21.0)", "mypy-boto3-serverlessrepo (>=1.21.0)", "mypy-boto3-service-quotas (>=1.21.0)", "mypy-boto3-servicecatalog (>=1.21.0)", "mypy-boto3-servicecatalog-appregistry (>=1.21.0)", "mypy-boto3-servicediscovery (>=1.21.0)", "mypy-boto3-ses (>=1.21.0)", "mypy-boto3-sesv2 (>=1.21.0)", "mypy-boto3-shield (>=1.21.0)", "mypy-boto3-signer (>=1.21.0)", "mypy-boto3-sms (>=1.21.0)", "mypy-boto3-sms-voice (>=1.21.0)", "mypy-boto3-snow-device-management (>=1.21.0)", "mypy-boto3-snowball (>=1.21.0)", "mypy-boto3-sns (>=1.21.0)", "mypy-boto3-sqs (>=1.21.0)", "mypy-boto3-ssm (>=1.21.0)", "mypy-boto3-ssm-contacts (>=1.21.0)", "mypy-boto3-ssm-incidents (>=1.21.0)", "mypy-boto3-sso (>=1.21.0)", "mypy-boto3-sso-admin (>=1.21.0)", "mypy-boto3-sso-oidc (>=1.21.0)", "mypy-boto3-stepfunctions (>=1.21.0)", "mypy-boto3-storagegateway (>=1.21.0)", "mypy-boto3-sts (>=1.21.0)", "mypy-boto3-support (>=1.21.0)", "mypy-boto3-swf (>=1.21.0)", "mypy-boto3-synthetics (>=1.21.0)", "mypy-boto3-textract (>=1.21.0)", "mypy-boto3-timestream-query (>=1.21.0)", "mypy-boto3-timestream-write (>=1.21.0)", "mypy-boto3-transcribe (>=1.21.0)", "mypy-boto3-transfer (>=1.21.0)", "mypy-boto3-translate (>=1.21.0)", "mypy-boto3-voice-id (>=1.21.0)", "mypy-boto3-waf (>=1.21.0)", "mypy-boto3-waf-regional (>=1.21.0)", "mypy-boto3-wafv2 (>=1.21.0)", "mypy-boto3-wellarchitected (>=1.21.0)", "mypy-boto3-wisdom (>=1.21.0)", "mypy-boto3-workdocs (>=1.21.0)", "mypy-boto3-worklink (>=1.21.0)", "mypy-boto3-workmail (>=1.21.0)", "mypy-boto3-workmailmessageflow (>=1.21.0)", "mypy-boto3-workspaces (>=1.21.0)", "mypy-boto3-workspaces-web (>=1.21.0)", "mypy-boto3-xray (>=1.21.0)"]
+amp = ["mypy-boto3-amp (>=1.21.0)"]
+amplify = ["mypy-boto3-amplify (>=1.21.0)"]
+amplifybackend = ["mypy-boto3-amplifybackend (>=1.21.0)"]
+amplifyuibuilder = ["mypy-boto3-amplifyuibuilder (>=1.21.0)"]
+apigateway = ["mypy-boto3-apigateway (>=1.21.0)"]
+apigatewaymanagementapi = ["mypy-boto3-apigatewaymanagementapi (>=1.21.0)"]
+apigatewayv2 = ["mypy-boto3-apigatewayv2 (>=1.21.0)"]
+appconfig = ["mypy-boto3-appconfig (>=1.21.0)"]
+appconfigdata = ["mypy-boto3-appconfigdata (>=1.21.0)"]
+appflow = ["mypy-boto3-appflow (>=1.21.0)"]
+appintegrations = ["mypy-boto3-appintegrations (>=1.21.0)"]
+application-autoscaling = ["mypy-boto3-application-autoscaling (>=1.21.0)"]
+application-insights = ["mypy-boto3-application-insights (>=1.21.0)"]
+applicationcostprofiler = ["mypy-boto3-applicationcostprofiler (>=1.21.0)"]
+appmesh = ["mypy-boto3-appmesh (>=1.21.0)"]
+apprunner = ["mypy-boto3-apprunner (>=1.21.0)"]
+appstream = ["mypy-boto3-appstream (>=1.21.0)"]
+appsync = ["mypy-boto3-appsync (>=1.21.0)"]
+athena = ["mypy-boto3-athena (>=1.21.0)"]
+auditmanager = ["mypy-boto3-auditmanager (>=1.21.0)"]
+autoscaling = ["mypy-boto3-autoscaling (>=1.21.0)"]
+autoscaling-plans = ["mypy-boto3-autoscaling-plans (>=1.21.0)"]
+backup = ["mypy-boto3-backup (>=1.21.0)"]
+backup-gateway = ["mypy-boto3-backup-gateway (>=1.21.0)"]
+batch = ["mypy-boto3-batch (>=1.21.0)"]
+braket = ["mypy-boto3-braket (>=1.21.0)"]
+budgets = ["mypy-boto3-budgets (>=1.21.0)"]
+ce = ["mypy-boto3-ce (>=1.21.0)"]
+chime = ["mypy-boto3-chime (>=1.21.0)"]
+chime-sdk-identity = ["mypy-boto3-chime-sdk-identity (>=1.21.0)"]
+chime-sdk-meetings = ["mypy-boto3-chime-sdk-meetings (>=1.21.0)"]
+chime-sdk-messaging = ["mypy-boto3-chime-sdk-messaging (>=1.21.0)"]
+cloud9 = ["mypy-boto3-cloud9 (>=1.21.0)"]
+cloudcontrol = ["mypy-boto3-cloudcontrol (>=1.21.0)"]
+clouddirectory = ["mypy-boto3-clouddirectory (>=1.21.0)"]
+cloudformation = ["mypy-boto3-cloudformation (>=1.21.0)"]
+cloudfront = ["mypy-boto3-cloudfront (>=1.21.0)"]
+cloudhsm = ["mypy-boto3-cloudhsm (>=1.21.0)"]
+cloudhsmv2 = ["mypy-boto3-cloudhsmv2 (>=1.21.0)"]
+cloudsearch = ["mypy-boto3-cloudsearch (>=1.21.0)"]
+cloudsearchdomain = ["mypy-boto3-cloudsearchdomain (>=1.21.0)"]
+cloudtrail = ["mypy-boto3-cloudtrail (>=1.21.0)"]
+cloudwatch = ["mypy-boto3-cloudwatch (>=1.21.0)"]
+codeartifact = ["mypy-boto3-codeartifact (>=1.21.0)"]
+codebuild = ["mypy-boto3-codebuild (>=1.21.0)"]
+codecommit = ["mypy-boto3-codecommit (>=1.21.0)"]
+codedeploy = ["mypy-boto3-codedeploy (>=1.21.0)"]
+codeguru-reviewer = ["mypy-boto3-codeguru-reviewer (>=1.21.0)"]
+codeguruprofiler = ["mypy-boto3-codeguruprofiler (>=1.21.0)"]
+codepipeline = ["mypy-boto3-codepipeline (>=1.21.0)"]
+codestar = ["mypy-boto3-codestar (>=1.21.0)"]
+codestar-connections = ["mypy-boto3-codestar-connections (>=1.21.0)"]
+codestar-notifications = ["mypy-boto3-codestar-notifications (>=1.21.0)"]
+cognito-identity = ["mypy-boto3-cognito-identity (>=1.21.0)"]
+cognito-idp = ["mypy-boto3-cognito-idp (>=1.21.0)"]
+cognito-sync = ["mypy-boto3-cognito-sync (>=1.21.0)"]
+comprehend = ["mypy-boto3-comprehend (>=1.21.0)"]
+comprehendmedical = ["mypy-boto3-comprehendmedical (>=1.21.0)"]
+compute-optimizer = ["mypy-boto3-compute-optimizer (>=1.21.0)"]
+config = ["mypy-boto3-config (>=1.21.0)"]
+connect = ["mypy-boto3-connect (>=1.21.0)"]
+connect-contact-lens = ["mypy-boto3-connect-contact-lens (>=1.21.0)"]
+connectparticipant = ["mypy-boto3-connectparticipant (>=1.21.0)"]
+cur = ["mypy-boto3-cur (>=1.21.0)"]
+customer-profiles = ["mypy-boto3-customer-profiles (>=1.21.0)"]
+databrew = ["mypy-boto3-databrew (>=1.21.0)"]
+dataexchange = ["mypy-boto3-dataexchange (>=1.21.0)"]
+datapipeline = ["mypy-boto3-datapipeline (>=1.21.0)"]
+datasync = ["mypy-boto3-datasync (>=1.21.0)"]
+dax = ["mypy-boto3-dax (>=1.21.0)"]
+detective = ["mypy-boto3-detective (>=1.21.0)"]
+devicefarm = ["mypy-boto3-devicefarm (>=1.21.0)"]
+devops-guru = ["mypy-boto3-devops-guru (>=1.21.0)"]
+directconnect = ["mypy-boto3-directconnect (>=1.21.0)"]
+discovery = ["mypy-boto3-discovery (>=1.21.0)"]
+dlm = ["mypy-boto3-dlm (>=1.21.0)"]
+dms = ["mypy-boto3-dms (>=1.21.0)"]
+docdb = ["mypy-boto3-docdb (>=1.21.0)"]
+drs = ["mypy-boto3-drs (>=1.21.0)"]
+ds = ["mypy-boto3-ds (>=1.21.0)"]
+dynamodb = ["mypy-boto3-dynamodb (>=1.21.0)"]
+dynamodbstreams = ["mypy-boto3-dynamodbstreams (>=1.21.0)"]
+ebs = ["mypy-boto3-ebs (>=1.21.0)"]
+ec2 = ["mypy-boto3-ec2 (>=1.21.0)"]
+ec2-instance-connect = ["mypy-boto3-ec2-instance-connect (>=1.21.0)"]
+ecr = ["mypy-boto3-ecr (>=1.21.0)"]
+ecr-public = ["mypy-boto3-ecr-public (>=1.21.0)"]
+ecs = ["mypy-boto3-ecs (>=1.21.0)"]
+efs = ["mypy-boto3-efs (>=1.21.0)"]
+eks = ["mypy-boto3-eks (>=1.21.0)"]
+elastic-inference = ["mypy-boto3-elastic-inference (>=1.21.0)"]
+elasticache = ["mypy-boto3-elasticache (>=1.21.0)"]
+elasticbeanstalk = ["mypy-boto3-elasticbeanstalk (>=1.21.0)"]
+elastictranscoder = ["mypy-boto3-elastictranscoder (>=1.21.0)"]
+elb = ["mypy-boto3-elb (>=1.21.0)"]
+elbv2 = ["mypy-boto3-elbv2 (>=1.21.0)"]
+emr = ["mypy-boto3-emr (>=1.21.0)"]
+emr-containers = ["mypy-boto3-emr-containers (>=1.21.0)"]
+es = ["mypy-boto3-es (>=1.21.0)"]
+essential = ["mypy-boto3-cloudformation (>=1.21.0)", "mypy-boto3-dynamodb (>=1.21.0)", "mypy-boto3-ec2 (>=1.21.0)", "mypy-boto3-lambda (>=1.21.0)", "mypy-boto3-rds (>=1.21.0)", "mypy-boto3-s3 (>=1.21.0)", "mypy-boto3-sqs (>=1.21.0)"]
+events = ["mypy-boto3-events (>=1.21.0)"]
+evidently = ["mypy-boto3-evidently (>=1.21.0)"]
+finspace = ["mypy-boto3-finspace (>=1.21.0)"]
+finspace-data = ["mypy-boto3-finspace-data (>=1.21.0)"]
+firehose = ["mypy-boto3-firehose (>=1.21.0)"]
+fis = ["mypy-boto3-fis (>=1.21.0)"]
+fms = ["mypy-boto3-fms (>=1.21.0)"]
+forecast = ["mypy-boto3-forecast (>=1.21.0)"]
+forecastquery = ["mypy-boto3-forecastquery (>=1.21.0)"]
+frauddetector = ["mypy-boto3-frauddetector (>=1.21.0)"]
+fsx = ["mypy-boto3-fsx (>=1.21.0)"]
+gamelift = ["mypy-boto3-gamelift (>=1.21.0)"]
+glacier = ["mypy-boto3-glacier (>=1.21.0)"]
+globalaccelerator = ["mypy-boto3-globalaccelerator (>=1.21.0)"]
+glue = ["mypy-boto3-glue (>=1.21.0)"]
+grafana = ["mypy-boto3-grafana (>=1.21.0)"]
+greengrass = ["mypy-boto3-greengrass (>=1.21.0)"]
+greengrassv2 = ["mypy-boto3-greengrassv2 (>=1.21.0)"]
+groundstation = ["mypy-boto3-groundstation (>=1.21.0)"]
+guardduty = ["mypy-boto3-guardduty (>=1.21.0)"]
+health = ["mypy-boto3-health (>=1.21.0)"]
+healthlake = ["mypy-boto3-healthlake (>=1.21.0)"]
+honeycode = ["mypy-boto3-honeycode (>=1.21.0)"]
+iam = ["mypy-boto3-iam (>=1.21.0)"]
+identitystore = ["mypy-boto3-identitystore (>=1.21.0)"]
+imagebuilder = ["mypy-boto3-imagebuilder (>=1.21.0)"]
+importexport = ["mypy-boto3-importexport (>=1.21.0)"]
+inspector = ["mypy-boto3-inspector (>=1.21.0)"]
+inspector2 = ["mypy-boto3-inspector2 (>=1.21.0)"]
+iot = ["mypy-boto3-iot (>=1.21.0)"]
+iot-data = ["mypy-boto3-iot-data (>=1.21.0)"]
+iot-jobs-data = ["mypy-boto3-iot-jobs-data (>=1.21.0)"]
+iot1click-devices = ["mypy-boto3-iot1click-devices (>=1.21.0)"]
+iot1click-projects = ["mypy-boto3-iot1click-projects (>=1.21.0)"]
+iotanalytics = ["mypy-boto3-iotanalytics (>=1.21.0)"]
+iotdeviceadvisor = ["mypy-boto3-iotdeviceadvisor (>=1.21.0)"]
+iotevents = ["mypy-boto3-iotevents (>=1.21.0)"]
+iotevents-data = ["mypy-boto3-iotevents-data (>=1.21.0)"]
+iotfleethub = ["mypy-boto3-iotfleethub (>=1.21.0)"]
+iotsecuretunneling = ["mypy-boto3-iotsecuretunneling (>=1.21.0)"]
+iotsitewise = ["mypy-boto3-iotsitewise (>=1.21.0)"]
+iotthingsgraph = ["mypy-boto3-iotthingsgraph (>=1.21.0)"]
+iottwinmaker = ["mypy-boto3-iottwinmaker (>=1.21.0)"]
+iotwireless = ["mypy-boto3-iotwireless (>=1.21.0)"]
+ivs = ["mypy-boto3-ivs (>=1.21.0)"]
+kafka = ["mypy-boto3-kafka (>=1.21.0)"]
+kafkaconnect = ["mypy-boto3-kafkaconnect (>=1.21.0)"]
+kendra = ["mypy-boto3-kendra (>=1.21.0)"]
+keyspaces = ["mypy-boto3-keyspaces (>=1.21.0)"]
+kinesis = ["mypy-boto3-kinesis (>=1.21.0)"]
+kinesis-video-archived-media = ["mypy-boto3-kinesis-video-archived-media (>=1.21.0)"]
+kinesis-video-media = ["mypy-boto3-kinesis-video-media (>=1.21.0)"]
+kinesis-video-signaling = ["mypy-boto3-kinesis-video-signaling (>=1.21.0)"]
+kinesisanalytics = ["mypy-boto3-kinesisanalytics (>=1.21.0)"]
+kinesisanalyticsv2 = ["mypy-boto3-kinesisanalyticsv2 (>=1.21.0)"]
+kinesisvideo = ["mypy-boto3-kinesisvideo (>=1.21.0)"]
+kms = ["mypy-boto3-kms (>=1.21.0)"]
+lakeformation = ["mypy-boto3-lakeformation (>=1.21.0)"]
+lambda = ["mypy-boto3-lambda (>=1.21.0)"]
+lex-models = ["mypy-boto3-lex-models (>=1.21.0)"]
+lex-runtime = ["mypy-boto3-lex-runtime (>=1.21.0)"]
+lexv2-models = ["mypy-boto3-lexv2-models (>=1.21.0)"]
+lexv2-runtime = ["mypy-boto3-lexv2-runtime (>=1.21.0)"]
+license-manager = ["mypy-boto3-license-manager (>=1.21.0)"]
+lightsail = ["mypy-boto3-lightsail (>=1.21.0)"]
+location = ["mypy-boto3-location (>=1.21.0)"]
+logs = ["mypy-boto3-logs (>=1.21.0)"]
+lookoutequipment = ["mypy-boto3-lookoutequipment (>=1.21.0)"]
+lookoutmetrics = ["mypy-boto3-lookoutmetrics (>=1.21.0)"]
+lookoutvision = ["mypy-boto3-lookoutvision (>=1.21.0)"]
+machinelearning = ["mypy-boto3-machinelearning (>=1.21.0)"]
+macie = ["mypy-boto3-macie (>=1.21.0)"]
+macie2 = ["mypy-boto3-macie2 (>=1.21.0)"]
+managedblockchain = ["mypy-boto3-managedblockchain (>=1.21.0)"]
+marketplace-catalog = ["mypy-boto3-marketplace-catalog (>=1.21.0)"]
+marketplace-entitlement = ["mypy-boto3-marketplace-entitlement (>=1.21.0)"]
+marketplacecommerceanalytics = ["mypy-boto3-marketplacecommerceanalytics (>=1.21.0)"]
+mediaconnect = ["mypy-boto3-mediaconnect (>=1.21.0)"]
+mediaconvert = ["mypy-boto3-mediaconvert (>=1.21.0)"]
+medialive = ["mypy-boto3-medialive (>=1.21.0)"]
+mediapackage = ["mypy-boto3-mediapackage (>=1.21.0)"]
+mediapackage-vod = ["mypy-boto3-mediapackage-vod (>=1.21.0)"]
+mediastore = ["mypy-boto3-mediastore (>=1.21.0)"]
+mediastore-data = ["mypy-boto3-mediastore-data (>=1.21.0)"]
+mediatailor = ["mypy-boto3-mediatailor (>=1.21.0)"]
+memorydb = ["mypy-boto3-memorydb (>=1.21.0)"]
+meteringmarketplace = ["mypy-boto3-meteringmarketplace (>=1.21.0)"]
+mgh = ["mypy-boto3-mgh (>=1.21.0)"]
+mgn = ["mypy-boto3-mgn (>=1.21.0)"]
+migration-hub-refactor-spaces = ["mypy-boto3-migration-hub-refactor-spaces (>=1.21.0)"]
+migrationhub-config = ["mypy-boto3-migrationhub-config (>=1.21.0)"]
+migrationhubstrategy = ["mypy-boto3-migrationhubstrategy (>=1.21.0)"]
+mobile = ["mypy-boto3-mobile (>=1.21.0)"]
+mq = ["mypy-boto3-mq (>=1.21.0)"]
+mturk = ["mypy-boto3-mturk (>=1.21.0)"]
+mwaa = ["mypy-boto3-mwaa (>=1.21.0)"]
+neptune = ["mypy-boto3-neptune (>=1.21.0)"]
+network-firewall = ["mypy-boto3-network-firewall (>=1.21.0)"]
+networkmanager = ["mypy-boto3-networkmanager (>=1.21.0)"]
+nimble = ["mypy-boto3-nimble (>=1.21.0)"]
+opensearch = ["mypy-boto3-opensearch (>=1.21.0)"]
+opsworks = ["mypy-boto3-opsworks (>=1.21.0)"]
+opsworkscm = ["mypy-boto3-opsworkscm (>=1.21.0)"]
+organizations = ["mypy-boto3-organizations (>=1.21.0)"]
+outposts = ["mypy-boto3-outposts (>=1.21.0)"]
+panorama = ["mypy-boto3-panorama (>=1.21.0)"]
+personalize = ["mypy-boto3-personalize (>=1.21.0)"]
+personalize-events = ["mypy-boto3-personalize-events (>=1.21.0)"]
+personalize-runtime = ["mypy-boto3-personalize-runtime (>=1.21.0)"]
+pi = ["mypy-boto3-pi (>=1.21.0)"]
+pinpoint = ["mypy-boto3-pinpoint (>=1.21.0)"]
+pinpoint-email = ["mypy-boto3-pinpoint-email (>=1.21.0)"]
+pinpoint-sms-voice = ["mypy-boto3-pinpoint-sms-voice (>=1.21.0)"]
+polly = ["mypy-boto3-polly (>=1.21.0)"]
+pricing = ["mypy-boto3-pricing (>=1.21.0)"]
+proton = ["mypy-boto3-proton (>=1.21.0)"]
+qldb = ["mypy-boto3-qldb (>=1.21.0)"]
+qldb-session = ["mypy-boto3-qldb-session (>=1.21.0)"]
+quicksight = ["mypy-boto3-quicksight (>=1.21.0)"]
+ram = ["mypy-boto3-ram (>=1.21.0)"]
+rbin = ["mypy-boto3-rbin (>=1.21.0)"]
+rds = ["mypy-boto3-rds (>=1.21.0)"]
+rds-data = ["mypy-boto3-rds-data (>=1.21.0)"]
+redshift = ["mypy-boto3-redshift (>=1.21.0)"]
+redshift-data = ["mypy-boto3-redshift-data (>=1.21.0)"]
+rekognition = ["mypy-boto3-rekognition (>=1.21.0)"]
+resiliencehub = ["mypy-boto3-resiliencehub (>=1.21.0)"]
+resource-groups = ["mypy-boto3-resource-groups (>=1.21.0)"]
+resourcegroupstaggingapi = ["mypy-boto3-resourcegroupstaggingapi (>=1.21.0)"]
+robomaker = ["mypy-boto3-robomaker (>=1.21.0)"]
+route53 = ["mypy-boto3-route53 (>=1.21.0)"]
+route53-recovery-cluster = ["mypy-boto3-route53-recovery-cluster (>=1.21.0)"]
+route53-recovery-control-config = ["mypy-boto3-route53-recovery-control-config (>=1.21.0)"]
+route53-recovery-readiness = ["mypy-boto3-route53-recovery-readiness (>=1.21.0)"]
+route53domains = ["mypy-boto3-route53domains (>=1.21.0)"]
+route53resolver = ["mypy-boto3-route53resolver (>=1.21.0)"]
+rum = ["mypy-boto3-rum (>=1.21.0)"]
+s3 = ["mypy-boto3-s3 (>=1.21.0)"]
+s3control = ["mypy-boto3-s3control (>=1.21.0)"]
+s3outposts = ["mypy-boto3-s3outposts (>=1.21.0)"]
+sagemaker = ["mypy-boto3-sagemaker (>=1.21.0)"]
+sagemaker-a2i-runtime = ["mypy-boto3-sagemaker-a2i-runtime (>=1.21.0)"]
+sagemaker-edge = ["mypy-boto3-sagemaker-edge (>=1.21.0)"]
+sagemaker-featurestore-runtime = ["mypy-boto3-sagemaker-featurestore-runtime (>=1.21.0)"]
+sagemaker-runtime = ["mypy-boto3-sagemaker-runtime (>=1.21.0)"]
+savingsplans = ["mypy-boto3-savingsplans (>=1.21.0)"]
+schemas = ["mypy-boto3-schemas (>=1.21.0)"]
+sdb = ["mypy-boto3-sdb (>=1.21.0)"]
+secretsmanager = ["mypy-boto3-secretsmanager (>=1.21.0)"]
+securityhub = ["mypy-boto3-securityhub (>=1.21.0)"]
+serverlessrepo = ["mypy-boto3-serverlessrepo (>=1.21.0)"]
+service-quotas = ["mypy-boto3-service-quotas (>=1.21.0)"]
+servicecatalog = ["mypy-boto3-servicecatalog (>=1.21.0)"]
+servicecatalog-appregistry = ["mypy-boto3-servicecatalog-appregistry (>=1.21.0)"]
+servicediscovery = ["mypy-boto3-servicediscovery (>=1.21.0)"]
+ses = ["mypy-boto3-ses (>=1.21.0)"]
+sesv2 = ["mypy-boto3-sesv2 (>=1.21.0)"]
+shield = ["mypy-boto3-shield (>=1.21.0)"]
+signer = ["mypy-boto3-signer (>=1.21.0)"]
+sms = ["mypy-boto3-sms (>=1.21.0)"]
+sms-voice = ["mypy-boto3-sms-voice (>=1.21.0)"]
+snow-device-management = ["mypy-boto3-snow-device-management (>=1.21.0)"]
+snowball = ["mypy-boto3-snowball (>=1.21.0)"]
+sns = ["mypy-boto3-sns (>=1.21.0)"]
+sqs = ["mypy-boto3-sqs (>=1.21.0)"]
+ssm = ["mypy-boto3-ssm (>=1.21.0)"]
+ssm-contacts = ["mypy-boto3-ssm-contacts (>=1.21.0)"]
+ssm-incidents = ["mypy-boto3-ssm-incidents (>=1.21.0)"]
+sso = ["mypy-boto3-sso (>=1.21.0)"]
+sso-admin = ["mypy-boto3-sso-admin (>=1.21.0)"]
+sso-oidc = ["mypy-boto3-sso-oidc (>=1.21.0)"]
+stepfunctions = ["mypy-boto3-stepfunctions (>=1.21.0)"]
+storagegateway = ["mypy-boto3-storagegateway (>=1.21.0)"]
+sts = ["mypy-boto3-sts (>=1.21.0)"]
+support = ["mypy-boto3-support (>=1.21.0)"]
+swf = ["mypy-boto3-swf (>=1.21.0)"]
+synthetics = ["mypy-boto3-synthetics (>=1.21.0)"]
+textract = ["mypy-boto3-textract (>=1.21.0)"]
+timestream-query = ["mypy-boto3-timestream-query (>=1.21.0)"]
+timestream-write = ["mypy-boto3-timestream-write (>=1.21.0)"]
+transcribe = ["mypy-boto3-transcribe (>=1.21.0)"]
+transfer = ["mypy-boto3-transfer (>=1.21.0)"]
+translate = ["mypy-boto3-translate (>=1.21.0)"]
+voice-id = ["mypy-boto3-voice-id (>=1.21.0)"]
+waf = ["mypy-boto3-waf (>=1.21.0)"]
+waf-regional = ["mypy-boto3-waf-regional (>=1.21.0)"]
+wafv2 = ["mypy-boto3-wafv2 (>=1.21.0)"]
+wellarchitected = ["mypy-boto3-wellarchitected (>=1.21.0)"]
+wisdom = ["mypy-boto3-wisdom (>=1.21.0)"]
+workdocs = ["mypy-boto3-workdocs (>=1.21.0)"]
+worklink = ["mypy-boto3-worklink (>=1.21.0)"]
+workmail = ["mypy-boto3-workmail (>=1.21.0)"]
+workmailmessageflow = ["mypy-boto3-workmailmessageflow (>=1.21.0)"]
+workspaces = ["mypy-boto3-workspaces (>=1.21.0)"]
+workspaces-web = ["mypy-boto3-workspaces-web (>=1.21.0)"]
+xray = ["mypy-boto3-xray (>=1.21.0)"]
+
+[[package]]
 name = "botocore"
-version = "1.24.1"
+version = "1.24.14"
 description = "Low-level, data-driven core of boto 3."
 category = "dev"
 optional = false
@@ -86,6 +405,17 @@ urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
 crt = ["awscrt (==0.12.5)"]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.24.14"
+description = "Type annotations for botocore 1.24.14 generated with mypy-boto3-builder 7.3.0"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "bump2version"
@@ -116,7 +446,7 @@ six = ">=1.11"
 
 [[package]]
 name = "click"
-version = "8.0.3"
+version = "8.0.4"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
@@ -312,6 +642,39 @@ dmypy = ["psutil (>=4.0)"]
 python2 = ["typed-ast (>=1.4.0,<2)"]
 
 [[package]]
+name = "mypy-boto3-cloudformation"
+version = "1.21.0"
+description = "Type annotations for boto3.CloudFormation 1.21.0 service generated by mypy-boto3-builder 7.0.4"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
+
+[[package]]
+name = "mypy-boto3-codecommit"
+version = "1.21.0"
+description = "Type annotations for boto3.CodeCommit 1.21.0 service generated by mypy-boto3-builder 7.0.4"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
+
+[[package]]
+name = "mypy-boto3-sts"
+version = "1.21.13"
+description = "Type annotations for boto3.STS 1.21.13 service generated with mypy-boto3-builder 7.3.0"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.9\""}
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -352,7 +715,7 @@ python-versions = ">=2.6"
 
 [[package]]
 name = "platformdirs"
-version = "2.5.0"
+version = "2.5.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
@@ -415,7 +778,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "restructuredtext-lint"
-version = "1.3.2"
+version = "1.4.0"
 description = "reStructuredText linter"
 category = "dev"
 optional = false
@@ -426,7 +789,7 @@ docutils = ">=0.11,<1.0"
 
 [[package]]
 name = "s3transfer"
-version = "0.5.1"
+version = "0.5.2"
 description = "An Amazon S3 Transfer Manager"
 category = "dev"
 optional = false
@@ -522,7 +885,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <3.11"
-content-hash = "a4080048176d98c087a7d1a337079a6e892516ca304866919fc5ed1fc7f1466d"
+content-hash = "a22ecfcf2c83ef620cb1b3d839d0b47f523baf3908238de21bd4825a2b24bdec"
 
 [metadata.files]
 attrs = [
@@ -539,12 +902,20 @@ black = [
     {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
 ]
 boto3 = [
-    {file = "boto3-1.21.1-py3-none-any.whl", hash = "sha256:d83e0f2dad07441c8d56542f5140e8cf264b05936e7bf64c88805ebda605cab9"},
-    {file = "boto3-1.21.1.tar.gz", hash = "sha256:9ce450f97e0368cf2535acfbc562b6684ca2ef4c9f58e36dda3ab0bac91f2b5e"},
+    {file = "boto3-1.21.14-py3-none-any.whl", hash = "sha256:d674fcd10c9603984599157941db66aa212d217dd073581c0ba2eab5e5da84fa"},
+    {file = "boto3-1.21.14.tar.gz", hash = "sha256:20d29e7b845eed3a39b43633443859bfa719ddbe3c8702ddfd999bc737fba9db"},
+]
+boto3-stubs-lite = [
+    {file = "boto3-stubs-lite-1.21.14.tar.gz", hash = "sha256:e4f465b2ac64cde3041985bc2ffc442dff88b982645b2300760623bb09da044e"},
+    {file = "boto3_stubs_lite-1.21.14-py3-none-any.whl", hash = "sha256:24b301b72d351701ef38792c832b8707df30ea8ef0c78cf962702e75d9190c16"},
 ]
 botocore = [
-    {file = "botocore-1.24.1-py3-none-any.whl", hash = "sha256:fbeb774c4542f4e85a3348c1e9928a31da4f9d743669686fbd5290bf94e8cc03"},
-    {file = "botocore-1.24.1.tar.gz", hash = "sha256:913542189e1df4487e354df942b9013ded7a5dc6c4e9f11af996a6c7d4aa6334"},
+    {file = "botocore-1.24.14-py3-none-any.whl", hash = "sha256:2c40f4fc3925b9057869beda1413a7b77edb7a28eb05c6265eaf6ca1ca7d3b63"},
+    {file = "botocore-1.24.14.tar.gz", hash = "sha256:9fe55f6eab0977b00afd90e770ef2c8b989fa7b18e5c14b22ba62216ec3b564a"},
+]
+botocore-stubs = [
+    {file = "botocore-stubs-1.24.14.tar.gz", hash = "sha256:fc83d0a8e1b1a195d3a5aafc8a701020ba98f07231667b56583b85823613c9ed"},
+    {file = "botocore_stubs-1.24.14-py3-none-any.whl", hash = "sha256:9ec990865498b9ed6d62c40fb96d605bdcd63f93c30464cfb2e7b1cdc0ad3486"},
 ]
 bump2version = [
     {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
@@ -555,8 +926,8 @@ cfn-lint = [
     {file = "cfn_lint-0.56.4-py3-none-any.whl", hash = "sha256:0ba396f0f4d4e57046f616f08e78abf962146b7c7f0beba45567ad7fa1251ff9"},
 ]
 click = [
-    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
-    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -635,6 +1006,18 @@ mypy = [
     {file = "mypy-0.931-py3-none-any.whl", hash = "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d"},
     {file = "mypy-0.931.tar.gz", hash = "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce"},
 ]
+mypy-boto3-cloudformation = [
+    {file = "mypy-boto3-cloudformation-1.21.0.tar.gz", hash = "sha256:f4eae0189897a060646d95f1c6e4644081d961b95c007dd1c1fbd3a0fa21616f"},
+    {file = "mypy_boto3_cloudformation-1.21.0-py3-none-any.whl", hash = "sha256:8c138380e9ccd6fa5ac6eb5c7f8a8c5f77005492cb26ca6b5b4fe19f2f199162"},
+]
+mypy-boto3-codecommit = [
+    {file = "mypy-boto3-codecommit-1.21.0.tar.gz", hash = "sha256:ed1261e36a15d75b1958e6809e268ad24de47b8c18983e483214aaef9f96ebfe"},
+    {file = "mypy_boto3_codecommit-1.21.0-py3-none-any.whl", hash = "sha256:ac438d5c79c112cd8ab70478afb8d1fd7917e6d1af5961a0f0ed1f0668a37064"},
+]
+mypy-boto3-sts = [
+    {file = "mypy-boto3-sts-1.21.13.tar.gz", hash = "sha256:b62d9f597826ba4668f9f3500dd6c74b71f55510de7f69d59df76a9ed4bc16c6"},
+    {file = "mypy_boto3_sts-1.21.13-py3-none-any.whl", hash = "sha256:452586399235f82d90b201a62a7c4a045d51eda34fb721f795a7f24c08b4c0e1"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -652,8 +1035,8 @@ pbr = [
     {file = "pbr-5.8.1.tar.gz", hash = "sha256:66bc5a34912f408bb3925bf21231cb6f59206267b7f63f3503ef865c1a292e25"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.5.0-py3-none-any.whl", hash = "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb"},
-    {file = "platformdirs-2.5.0.tar.gz", hash = "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"},
+    {file = "platformdirs-2.5.1-py3-none-any.whl", hash = "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"},
+    {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
@@ -730,11 +1113,11 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 restructuredtext-lint = [
-    {file = "restructuredtext_lint-1.3.2.tar.gz", hash = "sha256:d3b10a1fe2ecac537e51ae6d151b223b78de9fafdd50e5eb6b08c243df173c80"},
+    {file = "restructuredtext_lint-1.4.0.tar.gz", hash = "sha256:1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45"},
 ]
 s3transfer = [
-    {file = "s3transfer-0.5.1-py3-none-any.whl", hash = "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f"},
-    {file = "s3transfer-0.5.1.tar.gz", hash = "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a"},
+    {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},
+    {file = "s3transfer-0.5.2.tar.gz", hash = "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"},
 ]
 sarif-om = [
     {file = "sarif_om-1.0.4-py3-none-any.whl", hash = "sha256:539ef47a662329b1c8502388ad92457425e95dc0aaaf995fe46f4984c4771911"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,14 @@ python = ">=3.7.1, <3.11"
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"
+boto3-stubs-lite = {version = "*", extras = ["codecommit", "cloudformation", "sts"]}
 bump2version = "^1.0.1"
 cfn-lint = "^0.56.4"
 doc8 = "^0.10.1"
 flake8 = "^4.0.1"
 isort = "^5.10.1"
 mypy = "^0.931"
+typing-extensions = "^4.1.1"
 
 [tool.black]
 line-length = 120

--- a/validate.sh
+++ b/validate.sh
@@ -18,7 +18,6 @@ set -ex
 isort --check .
 black --check .
 
-pip install 'boto3-stubs[codecommit,cloudformation,sts]'
 for DIR in "cli" "core"
 do
   mypy --install-types --non-interactive ${DIR}

--- a/validate.sh
+++ b/validate.sh
@@ -17,10 +17,13 @@ set -ex
 
 isort --check .
 black --check .
+
+pip install 'boto3-stubs[codecommit,cloudformation,sts]'
 for DIR in "cli" "core"
 do
   mypy --install-types --non-interactive ${DIR}
 done
+
 flake8 .
 doc8 --ignore D002,D005 --max-line-length 120 docs/source
 cfn-lint -t cli/aws_ddk/data/cloudformation_templates/*


### PR DESCRIPTION
### Feature or Bugfix
Feature

### Detail

In order to have type checking for `boto3`-related code, I added `boto3-stubs-lite` library. I did not make any changes in the code, looks like there are no typing issues. But it could be helpful to have type checking for `boto3` anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
