### PR TITLE
(core) adding escape hatches for sqs_lambda stage

### DIFF
--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -100,16 +100,16 @@ class SqsToLambdaStage(DataStage):
             self._function = lambda_function
         elif code and handler:
             self._function = LambdaFactory.function(
-            self,
-            id=f"{id}-function",
-            environment_id=environment_id,
-            code=code,
-            handler=handler,
-            runtime=runtime,
-            role=role,
-            memory_size=memory_size,
-            timeout=timeout,
-        )
+                self,
+                id=f"{id}-function",
+                environment_id=environment_id,
+                code=code,
+                handler=handler,
+                runtime=runtime,
+                role=role,
+                memory_size=memory_size,
+                timeout=timeout,
+            )
         else:
             raise ValueError("'code' and 'handler' or 'lambda_function' must be set to instanstiate this stage")
 

--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -66,7 +66,8 @@ class SqsToLambdaStage(DataStage):
             The source code of the Lambda function
             Must be set if `lambda_function` is not.
         handler : str
-            The name of the method within the code that Lambda calls to execute the function. `index.lambda_handler` by default.
+            The name of the method within the code that Lambda calls to execute the function.
+            `index.lambda_handler` by default.
         runtime : Runtime
             The runtime environment for the Lambda function. `PYTHON_3_9` by default
         role : Optional[IRole]

--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -37,7 +37,7 @@ class SqsToLambdaStage(DataStage):
         id: str,
         environment_id: str,
         code: Optional[Code] = None,
-        handler: Optional[str] = None,
+        handler: str = "index.lambda_handler",
         runtime: Runtime = Runtime.PYTHON_3_9,
         role: Optional[IRole] = None,
         memory_size: Optional[int] = None,
@@ -65,9 +65,8 @@ class SqsToLambdaStage(DataStage):
         code : Optional[Code]
             The source code of the Lambda function
             Must be set if `lambda_function` is not.
-        handler : Optional[str]
-            The name of the method within the code that Lambda calls to execute the function
-            Must be set if `lambda_function` is not.
+        handler : str
+            The name of the method within the code that Lambda calls to execute the function. `index.lambda_handler` by default.
         runtime : Runtime
             The runtime environment for the Lambda function. `PYTHON_3_9` by default
         role : Optional[IRole]


### PR DESCRIPTION
### Feature
- Adding escape hatch for `aws_ddk_core.stages.SqsToLambdaStage`

### Detail
- Add arguments to `aws_ddk_core.stages.SqsToLambdaStage`
  - **lambda_function**: Optional[IFunction]
            Preexisting Lambda Function to use in stage. `None` by default
   - **sqs_queue**: Optional[IQueue]
            Preexisting SQS Queue  to use in stage. `None` by default
- Unit tests to validate the above arguments.
  - `test_sqs_lambda_stage.py::test_sqs_lambda_with_existing_function`
  - `test_sqs_lambda_stage.py::test_sqs_lambda_with_existing_queue`

### Relates
- #46 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
