### PR TITLE
(cli): Remove default AWS profile

### DIFF
--- a/cli/aws_ddk/__main__.py
+++ b/cli/aws_ddk/__main__.py
@@ -45,9 +45,10 @@ def enable_debug(format: str) -> None:
     logging.getLogger("sh").setLevel(logging.ERROR)
 
 
-def setup_boto_session(profile: str, region: Optional[str] = None) -> None:
+def setup_boto_session(profile: Optional[str], region: Optional[str] = None) -> None:
     # Setup profile and region globally in boto3 sessions
-    setup_default_session(profile_name=profile, region_name=region)
+    if profile:
+        setup_default_session(profile_name=profile, region_name=region)
     session: Session = _get_default_session()
     _logger.debug(f"profile: {session.profile_name}")
     _logger.debug(f"region: {session.region_name}")
@@ -143,9 +144,7 @@ def init(name: str, environment: str, template: Optional[str] = None, generate_o
     "--profile",
     "-p",
     type=str,
-    default="default",
     help="Use a specific profile from your AWS credentials file.",
-    show_default=True,
     required=False,
 )
 @click.option(
@@ -204,7 +203,7 @@ def init(name: str, environment: str, template: Optional[str] = None, generate_o
 )
 def bootstrap(
     environment: str,
-    profile: str,
+    profile: Optional[str] = None,
     region: Optional[str] = None,
     prefix: Optional[str] = None,
     qualifier: Optional[str] = None,
@@ -236,9 +235,7 @@ def bootstrap(
     "--profile",
     "-p",
     type=str,
-    default="default",
     help="Use a specific profile from your AWS credentials file.",
-    show_default=True,
     required=False,
 )
 @click.option(
@@ -267,7 +264,7 @@ def bootstrap(
 )
 def create_repository(
     name: str,
-    profile: str,
+    profile: Optional[str] = None,
     region: Optional[str] = None,
     description: Optional[str] = None,
     tags: Optional[Tuple[Tuple[str, str]]] = None,
@@ -291,9 +288,7 @@ def create_repository(
     "--profile",
     "-p",
     type=str,
-    default="default",
     help="Use a specific profile from your AWS credentials file.",
-    show_default=True,
     required=False,
 )
 @click.option(
@@ -319,7 +314,7 @@ def create_repository(
     required=False,
 )
 def deploy(
-    profile: str,
+    profile: Optional[str] = None,
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,
     output_dir: Optional[str] = None,

--- a/cli/aws_ddk/commands/create.py
+++ b/cli/aws_ddk/commands/create.py
@@ -31,8 +31,8 @@ def tuples_to_dict(tuples: Tuple[Tuple[str, str]]) -> Dict[str, str]:
 
 
 def create_code_repository(
-    profile: str,
     name: str,
+    profile: Optional[str] = None,
     description: Optional[str] = None,
     tags: Optional[Tuple[Tuple[str, str]]] = None,
 ) -> None:

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -23,7 +23,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def cdk_deploy(
-    profile: str,
+    profile: Optional[str] = None,
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,
     output_dir: Optional[str] = None,
@@ -34,11 +34,12 @@ def cdk_deploy(
     # generate command
     cmd = (
         "cdk deploy "
-        f"--profile {profile} "
         f"{'--require-approval ' + require_approval + ' ' if require_approval else ''}"
         f"{'-f ' if force else ''}"
         f"--output {output_dir if output_dir else '.ddk.out'}"
     )
+    if profile:
+        cmd += f" --profile {profile}"
 
     try:
         run(cmd)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- DDK cli is using `default` profile when none is supplied. This is bad behavior as there are [other ways](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) to set up a botocore session which do not rely on an AWS Profile. Instead we are assuming that `default` should be used if the user did not provide one, when in fact they could be using env variables or assuming a role provider in SSO

### Relates
- #60

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
