### PR TITLE
(core): Allow multiple cw alarms per stage

### DIFF
--- a/core/aws_ddk_core/pipelines/pipeline.py
+++ b/core/aws_ddk_core/pipelines/pipeline.py
@@ -90,9 +90,9 @@ class DataPipeline(Construct):
                 event_pattern=self._prev_stage.get_event_pattern(),
                 event_targets=stage.get_targets(),
             )
-        if self._notifications_topic:
+        if self._notifications_topic and stage.cloudwatch_alarms:
             for cloudwatch_alarm in stage.cloudwatch_alarms:
-                cloudwatch_alarm.add_alarm_action(SnsAction(self._notifications_topic))  # type: ignore
+                cloudwatch_alarm.add_alarm_action(SnsAction(self._notifications_topic))
         self._prev_stage = stage
         return self
 

--- a/core/aws_ddk_core/pipelines/pipeline.py
+++ b/core/aws_ddk_core/pipelines/pipeline.py
@@ -90,9 +90,9 @@ class DataPipeline(Construct):
                 event_pattern=self._prev_stage.get_event_pattern(),
                 event_targets=stage.get_targets(),
             )
-        if self._notifications_topic and stage.cloudwatch_alarms:
+        if self._notifications_topic:
             for cloudwatch_alarm in stage.cloudwatch_alarms:
-                cloudwatch_alarm.add_alarm_action(SnsAction(self._notifications_topic))
+                cloudwatch_alarm.add_alarm_action(SnsAction(self._notifications_topic))  # type: ignore
         self._prev_stage = stage
         return self
 

--- a/core/aws_ddk_core/pipelines/pipeline.py
+++ b/core/aws_ddk_core/pipelines/pipeline.py
@@ -90,8 +90,9 @@ class DataPipeline(Construct):
                 event_pattern=self._prev_stage.get_event_pattern(),
                 event_targets=stage.get_targets(),
             )
-        if self._notifications_topic and stage.cloudwatch_alarm:
-            stage.cloudwatch_alarm.add_alarm_action(SnsAction(self._notifications_topic))
+        if self._notifications_topic:
+            for cloudwatch_alarm in stage.cloudwatch_alarms:
+                cloudwatch_alarm.add_alarm_action(SnsAction(self._notifications_topic))  # type: ignore
         self._prev_stage = stage
         return self
 

--- a/core/aws_ddk_core/pipelines/stage.py
+++ b/core/aws_ddk_core/pipelines/stage.py
@@ -87,7 +87,7 @@ class DataStage(Construct):
         self.id: str = id
         self.name: Optional[str] = name
         self.description: Optional[str] = description
-        self._cloudwatch_alarms: Optional[List[IAlarm]] = None
+        self._cloudwatch_alarms: List[Optional[IAlarm]] = []
 
     @abstractmethod
     def get_targets(self) -> Optional[List[IRuleTarget]]:
@@ -142,22 +142,20 @@ class DataStage(Construct):
         alarm_evaluation_periods: Optional[int]
             The number of periods over which data is compared to the specified threshold. `1` by default.
         """
-        alarm = Alarm(
-            scope=self,
-            id=alarm_id,
-            comparison_operator=alarm_comparison_operator,
-            threshold=alarm_threshold,
-            evaluation_periods=alarm_evaluation_periods,
-            metric=alarm_metric,
+        self._cloudwatch_alarms.append(
+            Alarm(
+                scope=self,
+                id=alarm_id,
+                comparison_operator=alarm_comparison_operator,
+                threshold=alarm_threshold,
+                evaluation_periods=alarm_evaluation_periods,
+                metric=alarm_metric,
+            )
         )
-        if self._cloudwatch_alarms:
-            self._cloudwatch_alarms.append(alarm)
-        else:
-            self._cloudwatch_alarms = [alarm]
         return self
 
     @property
-    def cloudwatch_alarms(self) -> Optional[List[IAlarm]]:
+    def cloudwatch_alarms(self) -> List[Optional[IAlarm]]:
         """
         Return: List[Alarm]
             List of CloudWatch Alarms linked to the stage

--- a/core/aws_ddk_core/pipelines/stage.py
+++ b/core/aws_ddk_core/pipelines/stage.py
@@ -87,7 +87,7 @@ class DataStage(Construct):
         self.id: str = id
         self.name: Optional[str] = name
         self.description: Optional[str] = description
-        self._cloudwatch_alarms: List[Optional[IAlarm]] = []
+        self._cloudwatch_alarms: Optional[List[IAlarm]] = None
 
     @abstractmethod
     def get_targets(self) -> Optional[List[IRuleTarget]]:
@@ -142,20 +142,22 @@ class DataStage(Construct):
         alarm_evaluation_periods: Optional[int]
             The number of periods over which data is compared to the specified threshold. `1` by default.
         """
-        self._cloudwatch_alarms.append(
-            Alarm(
-                scope=self,
-                id=alarm_id,
-                comparison_operator=alarm_comparison_operator,
-                threshold=alarm_threshold,
-                evaluation_periods=alarm_evaluation_periods,
-                metric=alarm_metric,
-            )
+        alarm = Alarm(
+            scope=self,
+            id=alarm_id,
+            comparison_operator=alarm_comparison_operator,
+            threshold=alarm_threshold,
+            evaluation_periods=alarm_evaluation_periods,
+            metric=alarm_metric,
         )
+        if self._cloudwatch_alarms:
+            self._cloudwatch_alarms.append(alarm)
+        else:
+            self._cloudwatch_alarms = [alarm]
         return self
 
     @property
-    def cloudwatch_alarms(self) -> List[Optional[IAlarm]]:
+    def cloudwatch_alarms(self) -> Optional[List[IAlarm]]:
         """
         Return: List[Alarm]
             List of CloudWatch Alarms linked to the stage

--- a/core/aws_ddk_core/stages/kinesis_s3.py
+++ b/core/aws_ddk_core/stages/kinesis_s3.py
@@ -184,8 +184,9 @@ class KinesisToS3Stage(DataStage):
         )
 
         # Cloudwatch Alarms
-        self.set_alarm(
-            self._delivery_stream.metric(
+        self.add_alarm(
+            alarm_id=f"{id}-data-freshness",
+            alarm_metric=self._delivery_stream.metric(
                 "DeliveryToS3.DataFreshness",
                 period=buffering_interval if buffering_interval else Duration.seconds(300),
                 statistic="Maximum",

--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -156,8 +156,9 @@ class SqsToLambdaStage(DataStage):
 
         self._function.add_event_source(SqsEventSource(queue=self._queue, batch_size=batch_size))
 
-        self.set_alarm(
-            self._function.metric_errors(),
+        self.add_alarm(
+            alarm_id=f"{id}-function-errors",
+            alarm_metric=self._function.metric_errors(),
             alarm_threshold=lambda_function_errors_alarm_threshold,
             alarm_evaluation_periods=lambda_function_errors_alarm_evaluation_periods,
         )

--- a/core/tests/unit/test_basic_data_pipeline.py
+++ b/core/tests/unit/test_basic_data_pipeline.py
@@ -44,6 +44,9 @@ def test_basic_pipeline(test_stack: BaseStack) -> None:
         handler="commons.handlers.lambda_handler",
     )
     bucket.grant_read_write(sqs_lambda_stage.function)
+    sqs_lambda_stage.add_alarm(
+        alarm_id="dummy-sqs-lambda-throttles", alarm_metric=sqs_lambda_stage.function.metric_throttles()
+    )
     glue_stage = GlueTransformStage(
         scope=test_stack,
         id="dummy-glue",
@@ -56,6 +59,11 @@ def test_basic_pipeline(test_stack: BaseStack) -> None:
         id="dummy-appflow",
         environment_id="dev",
         flow_name="dummy-appflow-flow",
+    )
+    appflow_stage.add_alarm(
+        alarm_id="dummy-appflow-timedout",
+        alarm_metric=appflow_stage._state_machine.metric_timed_out(),
+        alarm_threshold=1,
     )
     athena_stage = AthenaSQLStage(
         scope=test_stack,
@@ -115,6 +123,22 @@ def test_basic_pipeline(test_stack: BaseStack) -> None:
                 pattern=[Match.object_like(pattern={"Ref": "dummypipelinepipelinedummypipelinenotifications161779A9"})]
             ),
             "Threshold": 5,
+        },
+    )
+    template.has_resource_properties(
+        "AWS::CloudWatch::Alarm",
+        props={
+            "Dimensions": Match.array_with(
+                pattern=[
+                    Match.object_like(
+                        pattern={
+                            "Name": "StateMachineArn",
+                            "Value": {"Ref": "dummyappflowdummyappflowstatemachine490B3250"},
+                        }
+                    )
+                ]
+            ),
+            "Threshold": 1,
         },
     )
     template.has_resource_properties(


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement

### Detail
- Current DDK Stage CW alarm implementation is limiting the user to one alarm. This PR extends the logic to multiples alarms, providing flexibility to the user to add as many as they wish

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
