### PR TITLE
(docs) expose configuration attributes for classes in documentation 

### DIFF
--- a/core/aws_ddk_core/base/stack.py
+++ b/core/aws_ddk_core/base/stack.py
@@ -65,17 +65,17 @@ class BaseStack(Stack):
             https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html#bootstrapping-synthesizers
         kwargs : Any
             Additional arguments
-        
+
         Supported DDK Environment Configuration
         ----------
         prefix: str
             Prefix for stack identifier.
         qualifier: str
-            Qualifier to disambiguate multiple environments in the same account. 
-            You can use this and leave the other naming properties empty if you 
+            Qualifier to disambiguate multiple environments in the same account.
+            You can use this and leave the other naming properties empty if you
             have deployed the bootstrap environment with standard names but only differnet qualifiers
         termination_protection: str
-            If this value is set, stack termination protection will be enabled. 
+            If this value is set, stack termination protection will be enabled.
         tags: Dict[str, str]
             Tag key/value pairs.
 

--- a/core/aws_ddk_core/base/stack.py
+++ b/core/aws_ddk_core/base/stack.py
@@ -65,6 +65,20 @@ class BaseStack(Stack):
             https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html#bootstrapping-synthesizers
         kwargs : Any
             Additional arguments
+        
+        Supported DDK Environment Configuration
+        ----------
+        prefix: str
+            Prefix for stack identifier.
+        qualifier: str
+            Qualifier to disambiguate multiple environments in the same account. 
+            You can use this and leave the other naming properties empty if you 
+            have deployed the bootstrap environment with standard names but only differnet qualifiers
+        termination_protection: str
+            If this value is set, stack termination protection will be enabled. 
+        tags: Dict[str, str]
+            Tag key/value pairs.
+
         """
         _logger.debug(f"Instantiating {id} stack")
 

--- a/core/aws_ddk_core/base/stack.py
+++ b/core/aws_ddk_core/base/stack.py
@@ -67,6 +67,7 @@ class BaseStack(Stack):
             Additional arguments
 
         Supported DDK Environment Configuration
+        https://awslabs.github.io/aws-ddk/release/latest/how-to/ddk-configuration.html
         ----------
         prefix: str
             Prefix for stack identifier.

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -120,6 +120,26 @@ class CICDPipelineStack(BaseStack):
             Environment
         kwargs: Any
             Additional args
+
+        Supported DDK Environment Configuration
+        ----------
+        cdk_version: str
+            Version of the AWS CDK to use in the deployment pipeline.
+        repository: str
+            Name of the CodeArtifact repository to pull artifacts from.
+        domain: str
+            Name of the CodeArtifact domain.
+        domain_owner: str
+            CodeArtifact domain owner account.
+        manual_approvals: str
+            Configure manual approvals if this parameter is set.
+        notifications_topic_arn: str
+            Existing SNS topic arn to use for pipeline notifications.
+        execute_security_lint: str
+            Configure security lint stage of pipeline if this parameter is set.
+        execute_tests: str
+            Configure tests stage of pipeline if this parameter is set.
+
         """
         self._config = Config()
         super().__init__(

--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -122,6 +122,7 @@ class CICDPipelineStack(BaseStack):
             Additional args
 
         Supported DDK Environment Configuration
+        https://awslabs.github.io/aws-ddk/release/latest/how-to/ddk-configuration.html
         ----------
         cdk_version: str
             Version of the AWS CDK to use in the deployment pipeline.


### PR DESCRIPTION
### Summary 
Adds documentation of available configuration attributes to `BaseStack` and `CICDPipelineStack` classes.


### Relates
- #88

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
