### PR TITLE
(core) remove Glue log encryption by default from security config

### DIFF
--- a/core/aws_ddk_core/resources/_glue.py
+++ b/core/aws_ddk_core/resources/_glue.py
@@ -141,6 +141,5 @@ class GlueFactory:
             scope,
             f"{id}-security-config",
             security_configuration_name=f"{id}-security-config",
-            cloud_watch_encryption=glue.CloudWatchEncryption(mode=glue.CloudWatchEncryptionMode.KMS),
             s3_encryption=glue.S3Encryption(mode=glue.S3EncryptionMode.S3_MANAGED),
         )


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
-  remove glue log encryption from default security config

### Relates
-  #124 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
