### PR TITLE
(cli) add 'stacks' argument for 'ddk deploy'

### DIFF
--- a/cli/aws_ddk/__main__.py
+++ b/cli/aws_ddk/__main__.py
@@ -17,7 +17,7 @@ import logging
 import os
 import re
 import sys
-from typing import List, Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 import click
 from aws_ddk.__metadata__ import __version__
@@ -319,15 +319,16 @@ def create_repository(
     required=False,
 )
 def deploy(
+    stacks: Iterable[str] = ["--all"],
     profile: Optional[str] = None,
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,
     output_dir: Optional[str] = None,
-    stacks: Optional[List[str]] = None,
 ) -> None:
     """Deploy DDK stacks to AWS account."""
     setup_boto_session(profile)
     cdk_deploy(
+        stacks=stacks,
         profile=profile,
         require_approval=require_approval,
         force=force,

--- a/cli/aws_ddk/__main__.py
+++ b/cli/aws_ddk/__main__.py
@@ -17,7 +17,7 @@ import logging
 import os
 import re
 import sys
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import click
 from aws_ddk.__metadata__ import __version__
@@ -284,6 +284,11 @@ def create_repository(
 
 
 @cli.command(name="deploy")
+@click.argument(
+    "stacks",
+    type=list,
+    required=False,
+)
 @click.option(
     "--profile",
     "-p",
@@ -318,6 +323,7 @@ def deploy(
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,
     output_dir: Optional[str] = None,
+    stacks: Optional[List[str]] = None,
 ) -> None:
     """Deploy DDK stacks to AWS account."""
     setup_boto_session(profile)

--- a/cli/aws_ddk/__main__.py
+++ b/cli/aws_ddk/__main__.py
@@ -319,7 +319,7 @@ def create_repository(
     required=False,
 )
 def deploy(
-    stacks: Iterable[str] = ["--all"],
+    stacks: Optional[Iterable[str]] = None,
     profile: Optional[str] = None,
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import List, Optional
+from typing import Iterable, Optional
 
 from aws_ddk.sh import run
 from aws_ddk.utils import get_account_id, get_region
@@ -23,11 +23,11 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def cdk_deploy(
+    stacks: Iterable[str] = ["--all"],
     profile: Optional[str] = None,
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,
     output_dir: Optional[str] = None,
-    stacks: Optional[List[str]] = ["--all"],
 ) -> None:
 
     echo(f"Deploying DDK stacks: {stacks} to AWS account {get_account_id()} and region {get_region()}...")

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -27,7 +27,7 @@ def cdk_deploy(
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,
     output_dir: Optional[str] = None,
-    stacks: Optional[List[str]] = ["--all"]
+    stacks: Optional[List[str]] = ["--all"],
 ) -> None:
 
     echo(f"Deploying DDK stacks: {stacks} to AWS account {get_account_id()} and region {get_region()}...")

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -23,7 +23,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def cdk_deploy(
-    stacks: Iterable[str] = ["--all"],
+    stacks: Iterable[str] = None,
     profile: Optional[str] = None,
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,
@@ -34,7 +34,7 @@ def cdk_deploy(
 
     # generate command
     cmd = (
-        f"cdk deploy {' '.join(stacks)} "
+        f"cdk deploy {' '.join(stacks) if stacks else '--all'} "
         f"{'--require-approval ' + require_approval + ' ' if require_approval else ''}"
         f"{'-f ' if force else ''}"
         f"--output {output_dir if output_dir else '.ddk.out'}"

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -23,7 +23,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def cdk_deploy(
-    stacks: Iterable[str] = None,
+    stacks: Optional[Iterable[str]] = None,
     profile: Optional[str] = None,
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from aws_ddk.sh import run
 from aws_ddk.utils import get_account_id, get_region
@@ -27,13 +27,14 @@ def cdk_deploy(
     require_approval: Optional[str] = None,
     force: Optional[bool] = None,
     output_dir: Optional[str] = None,
+    stacks: Optional[List[str]] = ["--all"]
 ) -> None:
 
-    echo(f"Deploying DDK stacks to AWS account {get_account_id()} and region {get_region()}...")
+    echo(f"Deploying DDK stacks: {stacks} to AWS account {get_account_id()} and region {get_region()}...")
 
     # generate command
     cmd = (
-        "cdk deploy --all "
+        f"cdk deploy {' '.join(stacks)} "
         f"{'--require-approval ' + require_approval + ' ' if require_approval else ''}"
         f"{'-f ' if force else ''}"
         f"--output {output_dir if output_dir else '.ddk.out'}"


### PR DESCRIPTION
### Enhancement
- Add argument for `ddk deploy` to allow explicitly setting stacks to deploy

### Usage
- `ddk deploy StackA StackB`

### Relates
- #121 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
