### PR TITLE
feat: Add support for Python in JSII and upgrade CDK version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,3 +98,28 @@ jobs:
         run: cd .repo && npx projen package:js
       - name: Collect js Artifact
         run: mv .repo/dist dist
+  package-python:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: "! needs.build.outputs.self_mutation_happened"
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.x
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create python artifact
+        run: cd .repo && npx projen package:python
+      - name: Collect python Artifact
+        run: mv .repo/dist dist

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,6 +7,7 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+      - status-success=package-python
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
@@ -23,3 +24,4 @@ pull_request_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+      - status-success=package-python

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.34.0",
+      "version": "2.38.1",
       "type": "build"
     },
     {
@@ -97,7 +97,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.34.0",
+      "version": "^2.38.1",
       "type": "peer"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.1.0",
+      "version": "2.34.0",
       "type": "build"
     },
     {
@@ -97,7 +97,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.1.0",
+      "version": "^2.34.0",
       "type": "peer"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -128,6 +128,9 @@
       "steps": [
         {
           "spawn": "package:js"
+        },
+        {
+          "spawn": "package:python"
         }
       ]
     },
@@ -137,6 +140,15 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target js"
+        }
+      ]
+    },
+    "package:python": {
+      "name": "package:python",
+      "description": "Create python language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --target python"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -3,10 +3,10 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: 'AWS Professional Services',
   authorAddress: 'aws-proserve-orion-dev@amazon.com',
 
-  cdkVersion: '2.1.0',
+  cdkVersion: '2.34.0',
   defaultReleaseBranch: 'main',
   release: false,
-  name: 'aws-ddk-dev',
+  name: 'aws-ddk-core',
   description: 'AWS DataOps Development Kit',
   repositoryUrl: 'https://github.com/awslabs/aws-ddk',
 
@@ -14,6 +14,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
   // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */
   // devDeps: [],             /* Build dependencies for this module. */
   // packageName: undefined,  /* The "name" in package.json. */
+
+  // Artifact config: Python
+  publishToPypi: {
+    distName: 'aws-ddk-core',
+    module: 'aws_ddk_core',
+  },
 
   gitignore: [
     '.vscode/',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -3,7 +3,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: 'AWS Professional Services',
   authorAddress: 'aws-proserve-orion-dev@amazon.com',
 
-  cdkVersion: '2.34.0',
+  cdkVersion: '2.38.1',
   defaultReleaseBranch: 'main',
   release: false,
   name: 'aws-ddk-core',

--- a/API.md
+++ b/API.md
@@ -492,9 +492,9 @@ The AWS account into which this stack will be deployed.
 This value is resolved according to the following rules:
 
 1. The value provided to `env.account` when the stack is defined. This can
-    either be a concerete account (e.g. `585695031111`) or the
-    `Aws.accountId` token.
-3. `Aws.accountId`, which represents the CloudFormation intrinsic reference
+    either be a concrete account (e.g. `585695031111`) or the
+    `Aws.ACCOUNT_ID` token.
+3. `Aws.ACCOUNT_ID`, which represents the CloudFormation intrinsic reference
     `{ "Ref": "AWS::AccountId" }` encoded as a string token.
 
 Preferably, you should use the return value as an opaque string and not
@@ -585,7 +585,7 @@ You can use this value to determine if two stacks are targeting the same
 environment.
 
 If either `stack.account` or `stack.region` are not concrete values (e.g.
-`Aws.account` or `Aws.region`) the special strings `unknown-account` and/or
+`Aws.ACCOUNT_ID` or `Aws.REGION`) the special strings `unknown-account` and/or
 `unknown-region` will be used respectively to indicate this stack is
 region/account-agnostic.
 
@@ -640,9 +640,9 @@ The AWS region into which this stack will be deployed (e.g. `us-west-2`).
 This value is resolved according to the following rules:
 
 1. The value provided to `env.region` when the stack is defined. This can
-    either be a concerete region (e.g. `us-west-2`) or the `Aws.region`
+    either be a concerete region (e.g. `us-west-2`) or the `Aws.REGION`
     token.
-3. `Aws.region`, which is represents the CloudFormation intrinsic reference
+3. `Aws.REGION`, which is represents the CloudFormation intrinsic reference
     `{ "Ref": "AWS::Region" }` encoded as a string token.
 
 Preferably, you should use the return value as an opaque string and not
@@ -693,7 +693,7 @@ name. Stacks that are defined deeper within the tree will use a hashed naming
 scheme based on the construct path to ensure uniqueness.
 
 If you wish to obtain the deploy-time AWS::StackName intrinsic,
-you can use `Aws.stackName` directly.
+you can use `Aws.STACK_NAME` directly.
 
 ---
 
@@ -1415,9 +1415,9 @@ The AWS account into which this stack will be deployed.
 This value is resolved according to the following rules:
 
 1. The value provided to `env.account` when the stack is defined. This can
-    either be a concerete account (e.g. `585695031111`) or the
-    `Aws.accountId` token.
-3. `Aws.accountId`, which represents the CloudFormation intrinsic reference
+    either be a concrete account (e.g. `585695031111`) or the
+    `Aws.ACCOUNT_ID` token.
+3. `Aws.ACCOUNT_ID`, which represents the CloudFormation intrinsic reference
     `{ "Ref": "AWS::AccountId" }` encoded as a string token.
 
 Preferably, you should use the return value as an opaque string and not
@@ -1508,7 +1508,7 @@ You can use this value to determine if two stacks are targeting the same
 environment.
 
 If either `stack.account` or `stack.region` are not concrete values (e.g.
-`Aws.account` or `Aws.region`) the special strings `unknown-account` and/or
+`Aws.ACCOUNT_ID` or `Aws.REGION`) the special strings `unknown-account` and/or
 `unknown-region` will be used respectively to indicate this stack is
 region/account-agnostic.
 
@@ -1563,9 +1563,9 @@ The AWS region into which this stack will be deployed (e.g. `us-west-2`).
 This value is resolved according to the following rules:
 
 1. The value provided to `env.region` when the stack is defined. This can
-    either be a concerete region (e.g. `us-west-2`) or the `Aws.region`
+    either be a concerete region (e.g. `us-west-2`) or the `Aws.REGION`
     token.
-3. `Aws.region`, which is represents the CloudFormation intrinsic reference
+3. `Aws.REGION`, which is represents the CloudFormation intrinsic reference
     `{ "Ref": "AWS::Region" }` encoded as a string token.
 
 Preferably, you should use the return value as an opaque string and not
@@ -1616,7 +1616,7 @@ name. Stacks that are defined deeper within the tree will use a hashed naming
 scheme based on the construct path to ensure uniqueness.
 
 If you wish to obtain the deploy-time AWS::StackName intrinsic,
-you can use `Aws.stackName` directly.
+you can use `Aws.STACK_NAME` directly.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2,39 +2,39 @@
 
 ## Constructs <a name="Constructs" id="Constructs"></a>
 
-### BaseStack <a name="BaseStack" id="aws-ddk-dev.BaseStack"></a>
+### BaseStack <a name="BaseStack" id="aws-ddk-core.BaseStack"></a>
 
-#### Initializers <a name="Initializers" id="aws-ddk-dev.BaseStack.Initializer"></a>
+#### Initializers <a name="Initializers" id="aws-ddk-core.BaseStack.Initializer"></a>
 
 ```typescript
-import { BaseStack } from 'aws-ddk-dev'
+import { BaseStack } from 'aws-ddk-core'
 
 new BaseStack(scope: Construct, id: string, props?: BaseStackProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.BaseStack.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.BaseStack.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.BaseStack.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-dev.BaseStackProps">BaseStackProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.BaseStack.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.BaseStack.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.BaseStack.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-core.BaseStackProps">BaseStackProps</a></code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-dev.BaseStack.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-core.BaseStack.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.BaseStack.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.BaseStack.Initializer.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="props" id="aws-ddk-dev.BaseStack.Initializer.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="props" id="aws-ddk-core.BaseStack.Initializer.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.BaseStackProps">BaseStackProps</a>
+- *Type:* <a href="#aws-ddk-core.BaseStackProps">BaseStackProps</a>
 
 ---
 
@@ -42,21 +42,22 @@ new BaseStack(scope: Construct, id: string, props?: BaseStackProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.BaseStack.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#aws-ddk-dev.BaseStack.addDependency">addDependency</a></code> | Add a dependency between this stack and another stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.addTransform">addTransform</a></code> | Add a Transform to this stack. A Transform is a macro that AWS CloudFormation uses to process your template. |
-| <code><a href="#aws-ddk-dev.BaseStack.exportValue">exportValue</a></code> | Create a CloudFormation Export for a value. |
-| <code><a href="#aws-ddk-dev.BaseStack.formatArn">formatArn</a></code> | Creates an ARN from components. |
-| <code><a href="#aws-ddk-dev.BaseStack.getLogicalId">getLogicalId</a></code> | Allocates a stack-unique CloudFormation-compatible logical identity for a specific resource. |
-| <code><a href="#aws-ddk-dev.BaseStack.renameLogicalId">renameLogicalId</a></code> | Rename a generated logical identities. |
-| <code><a href="#aws-ddk-dev.BaseStack.reportMissingContextKey">reportMissingContextKey</a></code> | Indicate that a context key was expected. |
-| <code><a href="#aws-ddk-dev.BaseStack.resolve">resolve</a></code> | Resolve a tokenized value in the context of the current stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.splitArn">splitArn</a></code> | Splits the provided ARN into its components. |
-| <code><a href="#aws-ddk-dev.BaseStack.toJsonString">toJsonString</a></code> | Convert an object, potentially containing tokens, to a JSON string. |
+| <code><a href="#aws-ddk-core.BaseStack.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-ddk-core.BaseStack.addDependency">addDependency</a></code> | Add a dependency between this stack and another stack. |
+| <code><a href="#aws-ddk-core.BaseStack.addTransform">addTransform</a></code> | Add a Transform to this stack. A Transform is a macro that AWS CloudFormation uses to process your template. |
+| <code><a href="#aws-ddk-core.BaseStack.exportValue">exportValue</a></code> | Create a CloudFormation Export for a value. |
+| <code><a href="#aws-ddk-core.BaseStack.formatArn">formatArn</a></code> | Creates an ARN from components. |
+| <code><a href="#aws-ddk-core.BaseStack.getLogicalId">getLogicalId</a></code> | Allocates a stack-unique CloudFormation-compatible logical identity for a specific resource. |
+| <code><a href="#aws-ddk-core.BaseStack.regionalFact">regionalFact</a></code> | Look up a fact value for the given fact for the region of this stack. |
+| <code><a href="#aws-ddk-core.BaseStack.renameLogicalId">renameLogicalId</a></code> | Rename a generated logical identities. |
+| <code><a href="#aws-ddk-core.BaseStack.reportMissingContextKey">reportMissingContextKey</a></code> | Indicate that a context key was expected. |
+| <code><a href="#aws-ddk-core.BaseStack.resolve">resolve</a></code> | Resolve a tokenized value in the context of the current stack. |
+| <code><a href="#aws-ddk-core.BaseStack.splitArn">splitArn</a></code> | Splits the provided ARN into its components. |
+| <code><a href="#aws-ddk-core.BaseStack.toJsonString">toJsonString</a></code> | Convert an object, potentially containing tokens, to a JSON string. |
 
 ---
 
-##### `toString` <a name="toString" id="aws-ddk-dev.BaseStack.toString"></a>
+##### `toString` <a name="toString" id="aws-ddk-core.BaseStack.toString"></a>
 
 ```typescript
 public toString(): string
@@ -64,7 +65,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addDependency` <a name="addDependency" id="aws-ddk-dev.BaseStack.addDependency"></a>
+##### `addDependency` <a name="addDependency" id="aws-ddk-core.BaseStack.addDependency"></a>
 
 ```typescript
 public addDependency(target: Stack, reason?: string): void
@@ -75,19 +76,19 @@ Add a dependency between this stack and another stack.
 This can be used to define dependencies between any two stacks within an
 app, and also supports nested stacks.
 
-###### `target`<sup>Required</sup> <a name="target" id="aws-ddk-dev.BaseStack.addDependency.parameter.target"></a>
+###### `target`<sup>Required</sup> <a name="target" id="aws-ddk-core.BaseStack.addDependency.parameter.target"></a>
 
 - *Type:* aws-cdk-lib.Stack
 
 ---
 
-###### `reason`<sup>Optional</sup> <a name="reason" id="aws-ddk-dev.BaseStack.addDependency.parameter.reason"></a>
+###### `reason`<sup>Optional</sup> <a name="reason" id="aws-ddk-core.BaseStack.addDependency.parameter.reason"></a>
 
 - *Type:* string
 
 ---
 
-##### `addTransform` <a name="addTransform" id="aws-ddk-dev.BaseStack.addTransform"></a>
+##### `addTransform` <a name="addTransform" id="aws-ddk-core.BaseStack.addTransform"></a>
 
 ```typescript
 public addTransform(transform: string): void
@@ -108,7 +109,7 @@ stack.addTransform('AWS::Serverless-2016-10-31')
 ```
 
 
-###### `transform`<sup>Required</sup> <a name="transform" id="aws-ddk-dev.BaseStack.addTransform.parameter.transform"></a>
+###### `transform`<sup>Required</sup> <a name="transform" id="aws-ddk-core.BaseStack.addTransform.parameter.transform"></a>
 
 - *Type:* string
 
@@ -116,7 +117,7 @@ The transform to add.
 
 ---
 
-##### `exportValue` <a name="exportValue" id="aws-ddk-dev.BaseStack.exportValue"></a>
+##### `exportValue` <a name="exportValue" id="aws-ddk-core.BaseStack.exportValue"></a>
 
 ```typescript
 public exportValue(exportedValue: any, options?: ExportValueOptions): string
@@ -167,19 +168,19 @@ Instead, the process takes two deployments:
 - Don't forget to remove the `exportValue()` call as well.
 - Deploy again (this time only the `producerStack` will be changed -- the bucket will be deleted).
 
-###### `exportedValue`<sup>Required</sup> <a name="exportedValue" id="aws-ddk-dev.BaseStack.exportValue.parameter.exportedValue"></a>
+###### `exportedValue`<sup>Required</sup> <a name="exportedValue" id="aws-ddk-core.BaseStack.exportValue.parameter.exportedValue"></a>
 
 - *Type:* any
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="options" id="aws-ddk-dev.BaseStack.exportValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="options" id="aws-ddk-core.BaseStack.exportValue.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.ExportValueOptions
 
 ---
 
-##### `formatArn` <a name="formatArn" id="aws-ddk-dev.BaseStack.formatArn"></a>
+##### `formatArn` <a name="formatArn" id="aws-ddk-core.BaseStack.formatArn"></a>
 
 ```typescript
 public formatArn(components: ArnComponents): string
@@ -195,19 +196,19 @@ into the generated ARN at the location that component corresponds to.
 
 The ARN will be formatted as follows:
 
-   arn:{partition}:{service}:{region}:{account}:{resource}{sep}}{resource-name}
+   arn:{partition}:{service}:{region}:{account}:{resource}{sep}{resource-name}
 
 The required ARN pieces that are omitted will be taken from the stack that
 the 'scope' is attached to. If all ARN pieces are supplied, the supplied scope
 can be 'undefined'.
 
-###### `components`<sup>Required</sup> <a name="components" id="aws-ddk-dev.BaseStack.formatArn.parameter.components"></a>
+###### `components`<sup>Required</sup> <a name="components" id="aws-ddk-core.BaseStack.formatArn.parameter.components"></a>
 
 - *Type:* aws-cdk-lib.ArnComponents
 
 ---
 
-##### `getLogicalId` <a name="getLogicalId" id="aws-ddk-dev.BaseStack.getLogicalId"></a>
+##### `getLogicalId` <a name="getLogicalId" id="aws-ddk-core.BaseStack.getLogicalId"></a>
 
 ```typescript
 public getLogicalId(element: CfnElement): string
@@ -223,7 +224,7 @@ This method uses the protected method `allocateLogicalId` to render the
 logical ID for an element. To modify the naming scheme, extend the `Stack`
 class and override this method.
 
-###### `element`<sup>Required</sup> <a name="element" id="aws-ddk-dev.BaseStack.getLogicalId.parameter.element"></a>
+###### `element`<sup>Required</sup> <a name="element" id="aws-ddk-core.BaseStack.getLogicalId.parameter.element"></a>
 
 - *Type:* aws-cdk-lib.CfnElement
 
@@ -231,7 +232,43 @@ The CloudFormation element for which a logical identity is needed.
 
 ---
 
-##### `renameLogicalId` <a name="renameLogicalId" id="aws-ddk-dev.BaseStack.renameLogicalId"></a>
+##### `regionalFact` <a name="regionalFact" id="aws-ddk-core.BaseStack.regionalFact"></a>
+
+```typescript
+public regionalFact(factName: string, defaultValue?: string): string
+```
+
+Look up a fact value for the given fact for the region of this stack.
+
+Will return a definite value only if the region of the current stack is resolved.
+If not, a lookup map will be added to the stack and the lookup will be done at
+CDK deployment time.
+
+What regions will be included in the lookup map is controlled by the
+`@aws-cdk/core:target-partitions` context value: it must be set to a list
+of partitions, and only regions from the given partitions will be included.
+If no such context key is set, all regions will be included.
+
+This function is intended to be used by construct library authors. Application
+builders can rely on the abstractions offered by construct libraries and do
+not have to worry about regional facts.
+
+If `defaultValue` is not given, it is an error if the fact is unknown for
+the given region.
+
+###### `factName`<sup>Required</sup> <a name="factName" id="aws-ddk-core.BaseStack.regionalFact.parameter.factName"></a>
+
+- *Type:* string
+
+---
+
+###### `defaultValue`<sup>Optional</sup> <a name="defaultValue" id="aws-ddk-core.BaseStack.regionalFact.parameter.defaultValue"></a>
+
+- *Type:* string
+
+---
+
+##### `renameLogicalId` <a name="renameLogicalId" id="aws-ddk-core.BaseStack.renameLogicalId"></a>
 
 ```typescript
 public renameLogicalId(oldId: string, newId: string): void
@@ -242,19 +279,19 @@ Rename a generated logical identities.
 To modify the naming scheme strategy, extend the `Stack` class and
 override the `allocateLogicalId` method.
 
-###### `oldId`<sup>Required</sup> <a name="oldId" id="aws-ddk-dev.BaseStack.renameLogicalId.parameter.oldId"></a>
+###### `oldId`<sup>Required</sup> <a name="oldId" id="aws-ddk-core.BaseStack.renameLogicalId.parameter.oldId"></a>
 
 - *Type:* string
 
 ---
 
-###### `newId`<sup>Required</sup> <a name="newId" id="aws-ddk-dev.BaseStack.renameLogicalId.parameter.newId"></a>
+###### `newId`<sup>Required</sup> <a name="newId" id="aws-ddk-core.BaseStack.renameLogicalId.parameter.newId"></a>
 
 - *Type:* string
 
 ---
 
-##### `reportMissingContextKey` <a name="reportMissingContextKey" id="aws-ddk-dev.BaseStack.reportMissingContextKey"></a>
+##### `reportMissingContextKey` <a name="reportMissingContextKey" id="aws-ddk-core.BaseStack.reportMissingContextKey"></a>
 
 ```typescript
 public reportMissingContextKey(report: MissingContext): void
@@ -265,7 +302,7 @@ Indicate that a context key was expected.
 Contains instructions which will be emitted into the cloud assembly on how
 the key should be supplied.
 
-###### `report`<sup>Required</sup> <a name="report" id="aws-ddk-dev.BaseStack.reportMissingContextKey.parameter.report"></a>
+###### `report`<sup>Required</sup> <a name="report" id="aws-ddk-core.BaseStack.reportMissingContextKey.parameter.report"></a>
 
 - *Type:* aws-cdk-lib.cloud_assembly_schema.MissingContext
 
@@ -273,7 +310,7 @@ The set of parameters needed to obtain the context.
 
 ---
 
-##### `resolve` <a name="resolve" id="aws-ddk-dev.BaseStack.resolve"></a>
+##### `resolve` <a name="resolve" id="aws-ddk-core.BaseStack.resolve"></a>
 
 ```typescript
 public resolve(obj: any): any
@@ -281,13 +318,13 @@ public resolve(obj: any): any
 
 Resolve a tokenized value in the context of the current stack.
 
-###### `obj`<sup>Required</sup> <a name="obj" id="aws-ddk-dev.BaseStack.resolve.parameter.obj"></a>
+###### `obj`<sup>Required</sup> <a name="obj" id="aws-ddk-core.BaseStack.resolve.parameter.obj"></a>
 
 - *Type:* any
 
 ---
 
-##### `splitArn` <a name="splitArn" id="aws-ddk-dev.BaseStack.splitArn"></a>
+##### `splitArn` <a name="splitArn" id="aws-ddk-core.BaseStack.splitArn"></a>
 
 ```typescript
 public splitArn(arn: string, arnFormat: ArnFormat): ArnComponents
@@ -300,7 +337,7 @@ and a Token representing a dynamic CloudFormation expression
 (in which case the returned components will also be dynamic CloudFormation expressions,
 encoded as Tokens).
 
-###### `arn`<sup>Required</sup> <a name="arn" id="aws-ddk-dev.BaseStack.splitArn.parameter.arn"></a>
+###### `arn`<sup>Required</sup> <a name="arn" id="aws-ddk-core.BaseStack.splitArn.parameter.arn"></a>
 
 - *Type:* string
 
@@ -308,7 +345,7 @@ the ARN to split into its components.
 
 ---
 
-###### `arnFormat`<sup>Required</sup> <a name="arnFormat" id="aws-ddk-dev.BaseStack.splitArn.parameter.arnFormat"></a>
+###### `arnFormat`<sup>Required</sup> <a name="arnFormat" id="aws-ddk-core.BaseStack.splitArn.parameter.arnFormat"></a>
 
 - *Type:* aws-cdk-lib.ArnFormat
 
@@ -316,7 +353,7 @@ the expected format of 'arn' - depends on what format the service 'arn' represen
 
 ---
 
-##### `toJsonString` <a name="toJsonString" id="aws-ddk-dev.BaseStack.toJsonString"></a>
+##### `toJsonString` <a name="toJsonString" id="aws-ddk-core.BaseStack.toJsonString"></a>
 
 ```typescript
 public toJsonString(obj: any, space?: number): string
@@ -324,13 +361,13 @@ public toJsonString(obj: any, space?: number): string
 
 Convert an object, potentially containing tokens, to a JSON string.
 
-###### `obj`<sup>Required</sup> <a name="obj" id="aws-ddk-dev.BaseStack.toJsonString.parameter.obj"></a>
+###### `obj`<sup>Required</sup> <a name="obj" id="aws-ddk-core.BaseStack.toJsonString.parameter.obj"></a>
 
 - *Type:* any
 
 ---
 
-###### `space`<sup>Optional</sup> <a name="space" id="aws-ddk-dev.BaseStack.toJsonString.parameter.space"></a>
+###### `space`<sup>Optional</sup> <a name="space" id="aws-ddk-core.BaseStack.toJsonString.parameter.space"></a>
 
 - *Type:* number
 
@@ -340,23 +377,23 @@ Convert an object, potentially containing tokens, to a JSON string.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.BaseStack.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#aws-ddk-dev.BaseStack.isStack">isStack</a></code> | Return whether the given object is a Stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.of">of</a></code> | Looks up the first stack scope in which `construct` is defined. |
+| <code><a href="#aws-ddk-core.BaseStack.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-ddk-core.BaseStack.isStack">isStack</a></code> | Return whether the given object is a Stack. |
+| <code><a href="#aws-ddk-core.BaseStack.of">of</a></code> | Looks up the first stack scope in which `construct` is defined. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-dev.BaseStack.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-core.BaseStack.isConstruct"></a>
 
 ```typescript
-import { BaseStack } from 'aws-ddk-dev'
+import { BaseStack } from 'aws-ddk-core'
 
 BaseStack.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.BaseStack.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.BaseStack.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -364,10 +401,10 @@ Any object.
 
 ---
 
-##### `isStack` <a name="isStack" id="aws-ddk-dev.BaseStack.isStack"></a>
+##### `isStack` <a name="isStack" id="aws-ddk-core.BaseStack.isStack"></a>
 
 ```typescript
-import { BaseStack } from 'aws-ddk-dev'
+import { BaseStack } from 'aws-ddk-core'
 
 BaseStack.isStack(x: any)
 ```
@@ -376,16 +413,16 @@ Return whether the given object is a Stack.
 
 We do attribute detection since we can't reliably use 'instanceof'.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.BaseStack.isStack.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.BaseStack.isStack.parameter.x"></a>
 
 - *Type:* any
 
 ---
 
-##### `of` <a name="of" id="aws-ddk-dev.BaseStack.of"></a>
+##### `of` <a name="of" id="aws-ddk-core.BaseStack.of"></a>
 
 ```typescript
-import { BaseStack } from 'aws-ddk-dev'
+import { BaseStack } from 'aws-ddk-core'
 
 BaseStack.of(construct: IConstruct)
 ```
@@ -394,7 +431,7 @@ Looks up the first stack scope in which `construct` is defined.
 
 Fails if there is no stack up the tree.
 
-###### `construct`<sup>Required</sup> <a name="construct" id="aws-ddk-dev.BaseStack.of.parameter.construct"></a>
+###### `construct`<sup>Required</sup> <a name="construct" id="aws-ddk-core.BaseStack.of.parameter.construct"></a>
 
 - *Type:* constructs.IConstruct
 
@@ -406,30 +443,31 @@ The construct to start the search from.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.BaseStack.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.account">account</a></code> | <code>string</code> | The AWS account into which this stack will be deployed. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.artifactId">artifactId</a></code> | <code>string</code> | The ID of the cloud assembly artifact for this stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.availabilityZones">availabilityZones</a></code> | <code>string[]</code> | Returns the list of AZs that are available in the AWS environment (account/region) associated with this stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.dependencies">dependencies</a></code> | <code>aws-cdk-lib.Stack[]</code> | Return the stacks this stack depends on. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.environment">environment</a></code> | <code>string</code> | The environment coordinates in which this stack is deployed. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.nested">nested</a></code> | <code>boolean</code> | Indicates if this is a nested stack, in which case `parentStack` will include a reference to it's parent. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.nestedStackParent">nestedStackParent</a></code> | <code>aws-cdk-lib.Stack</code> | If this is a nested stack, returns it's parent stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.nestedStackResource">nestedStackResource</a></code> | <code>aws-cdk-lib.CfnResource</code> | If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.notificationArns">notificationArns</a></code> | <code>string[]</code> | Returns the list of notification Amazon Resource Names (ARNs) for the current stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.partition">partition</a></code> | <code>string</code> | The partition in which this stack is defined. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.region">region</a></code> | <code>string</code> | The AWS region into which this stack will be deployed (e.g. `us-west-2`). |
-| <code><a href="#aws-ddk-dev.BaseStack.property.stackId">stackId</a></code> | <code>string</code> | The ID of the stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.stackName">stackName</a></code> | <code>string</code> | The concrete CloudFormation physical stack name. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method for this stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.tags">tags</a></code> | <code>aws-cdk-lib.TagManager</code> | Tags to be applied to the stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.templateFile">templateFile</a></code> | <code>string</code> | The name of the CloudFormation template file emitted to the output directory during synthesis. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.templateOptions">templateOptions</a></code> | <code>aws-cdk-lib.ITemplateOptions</code> | Options for CloudFormation template (like version, transform, description). |
-| <code><a href="#aws-ddk-dev.BaseStack.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether termination protection is enabled for this stack. |
-| <code><a href="#aws-ddk-dev.BaseStack.property.urlSuffix">urlSuffix</a></code> | <code>string</code> | The Amazon domain suffix for the region in which this stack is defined. |
+| <code><a href="#aws-ddk-core.BaseStack.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-ddk-core.BaseStack.property.account">account</a></code> | <code>string</code> | The AWS account into which this stack will be deployed. |
+| <code><a href="#aws-ddk-core.BaseStack.property.artifactId">artifactId</a></code> | <code>string</code> | The ID of the cloud assembly artifact for this stack. |
+| <code><a href="#aws-ddk-core.BaseStack.property.availabilityZones">availabilityZones</a></code> | <code>string[]</code> | Returns the list of AZs that are available in the AWS environment (account/region) associated with this stack. |
+| <code><a href="#aws-ddk-core.BaseStack.property.bundlingRequired">bundlingRequired</a></code> | <code>boolean</code> | Indicates whether the stack requires bundling or not. |
+| <code><a href="#aws-ddk-core.BaseStack.property.dependencies">dependencies</a></code> | <code>aws-cdk-lib.Stack[]</code> | Return the stacks this stack depends on. |
+| <code><a href="#aws-ddk-core.BaseStack.property.environment">environment</a></code> | <code>string</code> | The environment coordinates in which this stack is deployed. |
+| <code><a href="#aws-ddk-core.BaseStack.property.nested">nested</a></code> | <code>boolean</code> | Indicates if this is a nested stack, in which case `parentStack` will include a reference to it's parent. |
+| <code><a href="#aws-ddk-core.BaseStack.property.notificationArns">notificationArns</a></code> | <code>string[]</code> | Returns the list of notification Amazon Resource Names (ARNs) for the current stack. |
+| <code><a href="#aws-ddk-core.BaseStack.property.partition">partition</a></code> | <code>string</code> | The partition in which this stack is defined. |
+| <code><a href="#aws-ddk-core.BaseStack.property.region">region</a></code> | <code>string</code> | The AWS region into which this stack will be deployed (e.g. `us-west-2`). |
+| <code><a href="#aws-ddk-core.BaseStack.property.stackId">stackId</a></code> | <code>string</code> | The ID of the stack. |
+| <code><a href="#aws-ddk-core.BaseStack.property.stackName">stackName</a></code> | <code>string</code> | The concrete CloudFormation physical stack name. |
+| <code><a href="#aws-ddk-core.BaseStack.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method for this stack. |
+| <code><a href="#aws-ddk-core.BaseStack.property.tags">tags</a></code> | <code>aws-cdk-lib.TagManager</code> | Tags to be applied to the stack. |
+| <code><a href="#aws-ddk-core.BaseStack.property.templateFile">templateFile</a></code> | <code>string</code> | The name of the CloudFormation template file emitted to the output directory during synthesis. |
+| <code><a href="#aws-ddk-core.BaseStack.property.templateOptions">templateOptions</a></code> | <code>aws-cdk-lib.ITemplateOptions</code> | Options for CloudFormation template (like version, transform, description). |
+| <code><a href="#aws-ddk-core.BaseStack.property.urlSuffix">urlSuffix</a></code> | <code>string</code> | The Amazon domain suffix for the region in which this stack is defined. |
+| <code><a href="#aws-ddk-core.BaseStack.property.nestedStackParent">nestedStackParent</a></code> | <code>aws-cdk-lib.Stack</code> | If this is a nested stack, returns it's parent stack. |
+| <code><a href="#aws-ddk-core.BaseStack.property.nestedStackResource">nestedStackResource</a></code> | <code>aws-cdk-lib.CfnResource</code> | If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource. |
+| <code><a href="#aws-ddk-core.BaseStack.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether termination protection is enabled for this stack. |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-dev.BaseStack.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-core.BaseStack.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -441,7 +479,7 @@ The tree node.
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="aws-ddk-dev.BaseStack.property.account"></a>
+##### `account`<sup>Required</sup> <a name="account" id="aws-ddk-core.BaseStack.property.account"></a>
 
 ```typescript
 public readonly account: string;
@@ -470,7 +508,7 @@ implement some other region-agnostic behavior.
 
 ---
 
-##### `artifactId`<sup>Required</sup> <a name="artifactId" id="aws-ddk-dev.BaseStack.property.artifactId"></a>
+##### `artifactId`<sup>Required</sup> <a name="artifactId" id="aws-ddk-core.BaseStack.property.artifactId"></a>
 
 ```typescript
 public readonly artifactId: string;
@@ -482,7 +520,7 @@ The ID of the cloud assembly artifact for this stack.
 
 ---
 
-##### `availabilityZones`<sup>Required</sup> <a name="availabilityZones" id="aws-ddk-dev.BaseStack.property.availabilityZones"></a>
+##### `availabilityZones`<sup>Required</sup> <a name="availabilityZones" id="aws-ddk-core.BaseStack.property.availabilityZones"></a>
 
 ```typescript
 public readonly availabilityZones: string[];
@@ -505,7 +543,19 @@ To specify a different strategy for selecting availability zones override this m
 
 ---
 
-##### `dependencies`<sup>Required</sup> <a name="dependencies" id="aws-ddk-dev.BaseStack.property.dependencies"></a>
+##### `bundlingRequired`<sup>Required</sup> <a name="bundlingRequired" id="aws-ddk-core.BaseStack.property.bundlingRequired"></a>
+
+```typescript
+public readonly bundlingRequired: boolean;
+```
+
+- *Type:* boolean
+
+Indicates whether the stack requires bundling or not.
+
+---
+
+##### `dependencies`<sup>Required</sup> <a name="dependencies" id="aws-ddk-core.BaseStack.property.dependencies"></a>
 
 ```typescript
 public readonly dependencies: Stack[];
@@ -517,7 +567,7 @@ Return the stacks this stack depends on.
 
 ---
 
-##### `environment`<sup>Required</sup> <a name="environment" id="aws-ddk-dev.BaseStack.property.environment"></a>
+##### `environment`<sup>Required</sup> <a name="environment" id="aws-ddk-core.BaseStack.property.environment"></a>
 
 ```typescript
 public readonly environment: string;
@@ -541,7 +591,7 @@ region/account-agnostic.
 
 ---
 
-##### `nested`<sup>Required</sup> <a name="nested" id="aws-ddk-dev.BaseStack.property.nested"></a>
+##### `nested`<sup>Required</sup> <a name="nested" id="aws-ddk-core.BaseStack.property.nested"></a>
 
 ```typescript
 public readonly nested: boolean;
@@ -553,33 +603,7 @@ Indicates if this is a nested stack, in which case `parentStack` will include a 
 
 ---
 
-##### `nestedStackParent`<sup>Optional</sup> <a name="nestedStackParent" id="aws-ddk-dev.BaseStack.property.nestedStackParent"></a>
-
-```typescript
-public readonly nestedStackParent: Stack;
-```
-
-- *Type:* aws-cdk-lib.Stack
-
-If this is a nested stack, returns it's parent stack.
-
----
-
-##### `nestedStackResource`<sup>Optional</sup> <a name="nestedStackResource" id="aws-ddk-dev.BaseStack.property.nestedStackResource"></a>
-
-```typescript
-public readonly nestedStackResource: CfnResource;
-```
-
-- *Type:* aws-cdk-lib.CfnResource
-
-If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource.
-
-`undefined` for top-level (non-nested) stacks.
-
----
-
-##### `notificationArns`<sup>Required</sup> <a name="notificationArns" id="aws-ddk-dev.BaseStack.property.notificationArns"></a>
+##### `notificationArns`<sup>Required</sup> <a name="notificationArns" id="aws-ddk-core.BaseStack.property.notificationArns"></a>
 
 ```typescript
 public readonly notificationArns: string[];
@@ -591,7 +615,7 @@ Returns the list of notification Amazon Resource Names (ARNs) for the current st
 
 ---
 
-##### `partition`<sup>Required</sup> <a name="partition" id="aws-ddk-dev.BaseStack.property.partition"></a>
+##### `partition`<sup>Required</sup> <a name="partition" id="aws-ddk-core.BaseStack.property.partition"></a>
 
 ```typescript
 public readonly partition: string;
@@ -603,7 +627,7 @@ The partition in which this stack is defined.
 
 ---
 
-##### `region`<sup>Required</sup> <a name="region" id="aws-ddk-dev.BaseStack.property.region"></a>
+##### `region`<sup>Required</sup> <a name="region" id="aws-ddk-core.BaseStack.property.region"></a>
 
 ```typescript
 public readonly region: string;
@@ -632,7 +656,7 @@ implement some other region-agnostic behavior.
 
 ---
 
-##### `stackId`<sup>Required</sup> <a name="stackId" id="aws-ddk-dev.BaseStack.property.stackId"></a>
+##### `stackId`<sup>Required</sup> <a name="stackId" id="aws-ddk-core.BaseStack.property.stackId"></a>
 
 ```typescript
 public readonly stackId: string;
@@ -652,7 +676,7 @@ The ID of the stack.
 ```
 
 
-##### `stackName`<sup>Required</sup> <a name="stackName" id="aws-ddk-dev.BaseStack.property.stackName"></a>
+##### `stackName`<sup>Required</sup> <a name="stackName" id="aws-ddk-core.BaseStack.property.stackName"></a>
 
 ```typescript
 public readonly stackName: string;
@@ -673,7 +697,7 @@ you can use `Aws.stackName` directly.
 
 ---
 
-##### `synthesizer`<sup>Required</sup> <a name="synthesizer" id="aws-ddk-dev.BaseStack.property.synthesizer"></a>
+##### `synthesizer`<sup>Required</sup> <a name="synthesizer" id="aws-ddk-core.BaseStack.property.synthesizer"></a>
 
 ```typescript
 public readonly synthesizer: IStackSynthesizer;
@@ -685,7 +709,7 @@ Synthesis method for this stack.
 
 ---
 
-##### `tags`<sup>Required</sup> <a name="tags" id="aws-ddk-dev.BaseStack.property.tags"></a>
+##### `tags`<sup>Required</sup> <a name="tags" id="aws-ddk-core.BaseStack.property.tags"></a>
 
 ```typescript
 public readonly tags: TagManager;
@@ -697,7 +721,7 @@ Tags to be applied to the stack.
 
 ---
 
-##### `templateFile`<sup>Required</sup> <a name="templateFile" id="aws-ddk-dev.BaseStack.property.templateFile"></a>
+##### `templateFile`<sup>Required</sup> <a name="templateFile" id="aws-ddk-core.BaseStack.property.templateFile"></a>
 
 ```typescript
 public readonly templateFile: string;
@@ -711,7 +735,7 @@ Example value: `MyStack.template.json`
 
 ---
 
-##### `templateOptions`<sup>Required</sup> <a name="templateOptions" id="aws-ddk-dev.BaseStack.property.templateOptions"></a>
+##### `templateOptions`<sup>Required</sup> <a name="templateOptions" id="aws-ddk-core.BaseStack.property.templateOptions"></a>
 
 ```typescript
 public readonly templateOptions: ITemplateOptions;
@@ -723,19 +747,7 @@ Options for CloudFormation template (like version, transform, description).
 
 ---
 
-##### `terminationProtection`<sup>Optional</sup> <a name="terminationProtection" id="aws-ddk-dev.BaseStack.property.terminationProtection"></a>
-
-```typescript
-public readonly terminationProtection: boolean;
-```
-
-- *Type:* boolean
-
-Whether termination protection is enabled for this stack.
-
----
-
-##### `urlSuffix`<sup>Required</sup> <a name="urlSuffix" id="aws-ddk-dev.BaseStack.property.urlSuffix"></a>
+##### `urlSuffix`<sup>Required</sup> <a name="urlSuffix" id="aws-ddk-core.BaseStack.property.urlSuffix"></a>
 
 ```typescript
 public readonly urlSuffix: string;
@@ -747,52 +759,90 @@ The Amazon domain suffix for the region in which this stack is defined.
 
 ---
 
-
-### CICDPipelineStack <a name="CICDPipelineStack" id="aws-ddk-dev.CICDPipelineStack"></a>
-
-#### Initializers <a name="Initializers" id="aws-ddk-dev.CICDPipelineStack.Initializer"></a>
+##### `nestedStackParent`<sup>Optional</sup> <a name="nestedStackParent" id="aws-ddk-core.BaseStack.property.nestedStackParent"></a>
 
 ```typescript
-import { CICDPipelineStack } from 'aws-ddk-dev'
+public readonly nestedStackParent: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+If this is a nested stack, returns it's parent stack.
+
+---
+
+##### `nestedStackResource`<sup>Optional</sup> <a name="nestedStackResource" id="aws-ddk-core.BaseStack.property.nestedStackResource"></a>
+
+```typescript
+public readonly nestedStackResource: CfnResource;
+```
+
+- *Type:* aws-cdk-lib.CfnResource
+
+If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource.
+
+`undefined` for top-level (non-nested) stacks.
+
+---
+
+##### `terminationProtection`<sup>Optional</sup> <a name="terminationProtection" id="aws-ddk-core.BaseStack.property.terminationProtection"></a>
+
+```typescript
+public readonly terminationProtection: boolean;
+```
+
+- *Type:* boolean
+
+Whether termination protection is enabled for this stack.
+
+---
+
+
+### CICDPipelineStack <a name="CICDPipelineStack" id="aws-ddk-core.CICDPipelineStack"></a>
+
+#### Initializers <a name="Initializers" id="aws-ddk-core.CICDPipelineStack.Initializer"></a>
+
+```typescript
+import { CICDPipelineStack } from 'aws-ddk-core'
 
 new CICDPipelineStack(scope: Construct, id: string, environmentId: string, pipelineName: string, props?: StackProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.Initializer.parameter.environmentId">environmentId</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.Initializer.parameter.pipelineName">pipelineName</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.Initializer.parameter.props">props</a></code> | <code>aws-cdk-lib.StackProps</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.Initializer.parameter.environmentId">environmentId</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.Initializer.parameter.pipelineName">pipelineName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.Initializer.parameter.props">props</a></code> | <code>aws-cdk-lib.StackProps</code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-dev.CICDPipelineStack.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-core.CICDPipelineStack.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.CICDPipelineStack.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.CICDPipelineStack.Initializer.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-##### `environmentId`<sup>Required</sup> <a name="environmentId" id="aws-ddk-dev.CICDPipelineStack.Initializer.parameter.environmentId"></a>
+##### `environmentId`<sup>Required</sup> <a name="environmentId" id="aws-ddk-core.CICDPipelineStack.Initializer.parameter.environmentId"></a>
 
 - *Type:* string
 
 ---
 
-##### `pipelineName`<sup>Required</sup> <a name="pipelineName" id="aws-ddk-dev.CICDPipelineStack.Initializer.parameter.pipelineName"></a>
+##### `pipelineName`<sup>Required</sup> <a name="pipelineName" id="aws-ddk-core.CICDPipelineStack.Initializer.parameter.pipelineName"></a>
 
 - *Type:* string
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="props" id="aws-ddk-dev.CICDPipelineStack.Initializer.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="props" id="aws-ddk-core.CICDPipelineStack.Initializer.parameter.props"></a>
 
 - *Type:* aws-cdk-lib.StackProps
 
@@ -802,30 +852,31 @@ new CICDPipelineStack(scope: Construct, id: string, environmentId: string, pipel
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addDependency">addDependency</a></code> | Add a dependency between this stack and another stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addTransform">addTransform</a></code> | Add a Transform to this stack. A Transform is a macro that AWS CloudFormation uses to process your template. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.exportValue">exportValue</a></code> | Create a CloudFormation Export for a value. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.formatArn">formatArn</a></code> | Creates an ARN from components. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.getLogicalId">getLogicalId</a></code> | Allocates a stack-unique CloudFormation-compatible logical identity for a specific resource. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.renameLogicalId">renameLogicalId</a></code> | Rename a generated logical identities. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.reportMissingContextKey">reportMissingContextKey</a></code> | Indicate that a context key was expected. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.resolve">resolve</a></code> | Resolve a tokenized value in the context of the current stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.splitArn">splitArn</a></code> | Splits the provided ARN into its components. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.toJsonString">toJsonString</a></code> | Convert an object, potentially containing tokens, to a JSON string. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addCustomStage">addCustomStage</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addNotifications">addNotifications</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addSecurityLintStage">addSecurityLintStage</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addSourceAction">addSourceAction</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addStage">addStage</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addSynthAction">addSynthAction</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.addTestStage">addTestStage</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.buildPipeline">buildPipeline</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.synth">synth</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addDependency">addDependency</a></code> | Add a dependency between this stack and another stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addTransform">addTransform</a></code> | Add a Transform to this stack. A Transform is a macro that AWS CloudFormation uses to process your template. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.exportValue">exportValue</a></code> | Create a CloudFormation Export for a value. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.formatArn">formatArn</a></code> | Creates an ARN from components. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.getLogicalId">getLogicalId</a></code> | Allocates a stack-unique CloudFormation-compatible logical identity for a specific resource. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.regionalFact">regionalFact</a></code> | Look up a fact value for the given fact for the region of this stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.renameLogicalId">renameLogicalId</a></code> | Rename a generated logical identities. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.reportMissingContextKey">reportMissingContextKey</a></code> | Indicate that a context key was expected. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.resolve">resolve</a></code> | Resolve a tokenized value in the context of the current stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.splitArn">splitArn</a></code> | Splits the provided ARN into its components. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.toJsonString">toJsonString</a></code> | Convert an object, potentially containing tokens, to a JSON string. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addCustomStage">addCustomStage</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addNotifications">addNotifications</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addSecurityLintStage">addSecurityLintStage</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addSourceAction">addSourceAction</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addStage">addStage</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addSynthAction">addSynthAction</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.addTestStage">addTestStage</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.buildPipeline">buildPipeline</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.synth">synth</a></code> | *No description.* |
 
 ---
 
-##### `toString` <a name="toString" id="aws-ddk-dev.CICDPipelineStack.toString"></a>
+##### `toString` <a name="toString" id="aws-ddk-core.CICDPipelineStack.toString"></a>
 
 ```typescript
 public toString(): string
@@ -833,7 +884,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addDependency` <a name="addDependency" id="aws-ddk-dev.CICDPipelineStack.addDependency"></a>
+##### `addDependency` <a name="addDependency" id="aws-ddk-core.CICDPipelineStack.addDependency"></a>
 
 ```typescript
 public addDependency(target: Stack, reason?: string): void
@@ -844,19 +895,19 @@ Add a dependency between this stack and another stack.
 This can be used to define dependencies between any two stacks within an
 app, and also supports nested stacks.
 
-###### `target`<sup>Required</sup> <a name="target" id="aws-ddk-dev.CICDPipelineStack.addDependency.parameter.target"></a>
+###### `target`<sup>Required</sup> <a name="target" id="aws-ddk-core.CICDPipelineStack.addDependency.parameter.target"></a>
 
 - *Type:* aws-cdk-lib.Stack
 
 ---
 
-###### `reason`<sup>Optional</sup> <a name="reason" id="aws-ddk-dev.CICDPipelineStack.addDependency.parameter.reason"></a>
+###### `reason`<sup>Optional</sup> <a name="reason" id="aws-ddk-core.CICDPipelineStack.addDependency.parameter.reason"></a>
 
 - *Type:* string
 
 ---
 
-##### `addTransform` <a name="addTransform" id="aws-ddk-dev.CICDPipelineStack.addTransform"></a>
+##### `addTransform` <a name="addTransform" id="aws-ddk-core.CICDPipelineStack.addTransform"></a>
 
 ```typescript
 public addTransform(transform: string): void
@@ -877,7 +928,7 @@ stack.addTransform('AWS::Serverless-2016-10-31')
 ```
 
 
-###### `transform`<sup>Required</sup> <a name="transform" id="aws-ddk-dev.CICDPipelineStack.addTransform.parameter.transform"></a>
+###### `transform`<sup>Required</sup> <a name="transform" id="aws-ddk-core.CICDPipelineStack.addTransform.parameter.transform"></a>
 
 - *Type:* string
 
@@ -885,7 +936,7 @@ The transform to add.
 
 ---
 
-##### `exportValue` <a name="exportValue" id="aws-ddk-dev.CICDPipelineStack.exportValue"></a>
+##### `exportValue` <a name="exportValue" id="aws-ddk-core.CICDPipelineStack.exportValue"></a>
 
 ```typescript
 public exportValue(exportedValue: any, options?: ExportValueOptions): string
@@ -936,19 +987,19 @@ Instead, the process takes two deployments:
 - Don't forget to remove the `exportValue()` call as well.
 - Deploy again (this time only the `producerStack` will be changed -- the bucket will be deleted).
 
-###### `exportedValue`<sup>Required</sup> <a name="exportedValue" id="aws-ddk-dev.CICDPipelineStack.exportValue.parameter.exportedValue"></a>
+###### `exportedValue`<sup>Required</sup> <a name="exportedValue" id="aws-ddk-core.CICDPipelineStack.exportValue.parameter.exportedValue"></a>
 
 - *Type:* any
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="options" id="aws-ddk-dev.CICDPipelineStack.exportValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="options" id="aws-ddk-core.CICDPipelineStack.exportValue.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.ExportValueOptions
 
 ---
 
-##### `formatArn` <a name="formatArn" id="aws-ddk-dev.CICDPipelineStack.formatArn"></a>
+##### `formatArn` <a name="formatArn" id="aws-ddk-core.CICDPipelineStack.formatArn"></a>
 
 ```typescript
 public formatArn(components: ArnComponents): string
@@ -964,19 +1015,19 @@ into the generated ARN at the location that component corresponds to.
 
 The ARN will be formatted as follows:
 
-   arn:{partition}:{service}:{region}:{account}:{resource}{sep}}{resource-name}
+   arn:{partition}:{service}:{region}:{account}:{resource}{sep}{resource-name}
 
 The required ARN pieces that are omitted will be taken from the stack that
 the 'scope' is attached to. If all ARN pieces are supplied, the supplied scope
 can be 'undefined'.
 
-###### `components`<sup>Required</sup> <a name="components" id="aws-ddk-dev.CICDPipelineStack.formatArn.parameter.components"></a>
+###### `components`<sup>Required</sup> <a name="components" id="aws-ddk-core.CICDPipelineStack.formatArn.parameter.components"></a>
 
 - *Type:* aws-cdk-lib.ArnComponents
 
 ---
 
-##### `getLogicalId` <a name="getLogicalId" id="aws-ddk-dev.CICDPipelineStack.getLogicalId"></a>
+##### `getLogicalId` <a name="getLogicalId" id="aws-ddk-core.CICDPipelineStack.getLogicalId"></a>
 
 ```typescript
 public getLogicalId(element: CfnElement): string
@@ -992,7 +1043,7 @@ This method uses the protected method `allocateLogicalId` to render the
 logical ID for an element. To modify the naming scheme, extend the `Stack`
 class and override this method.
 
-###### `element`<sup>Required</sup> <a name="element" id="aws-ddk-dev.CICDPipelineStack.getLogicalId.parameter.element"></a>
+###### `element`<sup>Required</sup> <a name="element" id="aws-ddk-core.CICDPipelineStack.getLogicalId.parameter.element"></a>
 
 - *Type:* aws-cdk-lib.CfnElement
 
@@ -1000,7 +1051,43 @@ The CloudFormation element for which a logical identity is needed.
 
 ---
 
-##### `renameLogicalId` <a name="renameLogicalId" id="aws-ddk-dev.CICDPipelineStack.renameLogicalId"></a>
+##### `regionalFact` <a name="regionalFact" id="aws-ddk-core.CICDPipelineStack.regionalFact"></a>
+
+```typescript
+public regionalFact(factName: string, defaultValue?: string): string
+```
+
+Look up a fact value for the given fact for the region of this stack.
+
+Will return a definite value only if the region of the current stack is resolved.
+If not, a lookup map will be added to the stack and the lookup will be done at
+CDK deployment time.
+
+What regions will be included in the lookup map is controlled by the
+`@aws-cdk/core:target-partitions` context value: it must be set to a list
+of partitions, and only regions from the given partitions will be included.
+If no such context key is set, all regions will be included.
+
+This function is intended to be used by construct library authors. Application
+builders can rely on the abstractions offered by construct libraries and do
+not have to worry about regional facts.
+
+If `defaultValue` is not given, it is an error if the fact is unknown for
+the given region.
+
+###### `factName`<sup>Required</sup> <a name="factName" id="aws-ddk-core.CICDPipelineStack.regionalFact.parameter.factName"></a>
+
+- *Type:* string
+
+---
+
+###### `defaultValue`<sup>Optional</sup> <a name="defaultValue" id="aws-ddk-core.CICDPipelineStack.regionalFact.parameter.defaultValue"></a>
+
+- *Type:* string
+
+---
+
+##### `renameLogicalId` <a name="renameLogicalId" id="aws-ddk-core.CICDPipelineStack.renameLogicalId"></a>
 
 ```typescript
 public renameLogicalId(oldId: string, newId: string): void
@@ -1011,19 +1098,19 @@ Rename a generated logical identities.
 To modify the naming scheme strategy, extend the `Stack` class and
 override the `allocateLogicalId` method.
 
-###### `oldId`<sup>Required</sup> <a name="oldId" id="aws-ddk-dev.CICDPipelineStack.renameLogicalId.parameter.oldId"></a>
+###### `oldId`<sup>Required</sup> <a name="oldId" id="aws-ddk-core.CICDPipelineStack.renameLogicalId.parameter.oldId"></a>
 
 - *Type:* string
 
 ---
 
-###### `newId`<sup>Required</sup> <a name="newId" id="aws-ddk-dev.CICDPipelineStack.renameLogicalId.parameter.newId"></a>
+###### `newId`<sup>Required</sup> <a name="newId" id="aws-ddk-core.CICDPipelineStack.renameLogicalId.parameter.newId"></a>
 
 - *Type:* string
 
 ---
 
-##### `reportMissingContextKey` <a name="reportMissingContextKey" id="aws-ddk-dev.CICDPipelineStack.reportMissingContextKey"></a>
+##### `reportMissingContextKey` <a name="reportMissingContextKey" id="aws-ddk-core.CICDPipelineStack.reportMissingContextKey"></a>
 
 ```typescript
 public reportMissingContextKey(report: MissingContext): void
@@ -1034,7 +1121,7 @@ Indicate that a context key was expected.
 Contains instructions which will be emitted into the cloud assembly on how
 the key should be supplied.
 
-###### `report`<sup>Required</sup> <a name="report" id="aws-ddk-dev.CICDPipelineStack.reportMissingContextKey.parameter.report"></a>
+###### `report`<sup>Required</sup> <a name="report" id="aws-ddk-core.CICDPipelineStack.reportMissingContextKey.parameter.report"></a>
 
 - *Type:* aws-cdk-lib.cloud_assembly_schema.MissingContext
 
@@ -1042,7 +1129,7 @@ The set of parameters needed to obtain the context.
 
 ---
 
-##### `resolve` <a name="resolve" id="aws-ddk-dev.CICDPipelineStack.resolve"></a>
+##### `resolve` <a name="resolve" id="aws-ddk-core.CICDPipelineStack.resolve"></a>
 
 ```typescript
 public resolve(obj: any): any
@@ -1050,13 +1137,13 @@ public resolve(obj: any): any
 
 Resolve a tokenized value in the context of the current stack.
 
-###### `obj`<sup>Required</sup> <a name="obj" id="aws-ddk-dev.CICDPipelineStack.resolve.parameter.obj"></a>
+###### `obj`<sup>Required</sup> <a name="obj" id="aws-ddk-core.CICDPipelineStack.resolve.parameter.obj"></a>
 
 - *Type:* any
 
 ---
 
-##### `splitArn` <a name="splitArn" id="aws-ddk-dev.CICDPipelineStack.splitArn"></a>
+##### `splitArn` <a name="splitArn" id="aws-ddk-core.CICDPipelineStack.splitArn"></a>
 
 ```typescript
 public splitArn(arn: string, arnFormat: ArnFormat): ArnComponents
@@ -1069,7 +1156,7 @@ and a Token representing a dynamic CloudFormation expression
 (in which case the returned components will also be dynamic CloudFormation expressions,
 encoded as Tokens).
 
-###### `arn`<sup>Required</sup> <a name="arn" id="aws-ddk-dev.CICDPipelineStack.splitArn.parameter.arn"></a>
+###### `arn`<sup>Required</sup> <a name="arn" id="aws-ddk-core.CICDPipelineStack.splitArn.parameter.arn"></a>
 
 - *Type:* string
 
@@ -1077,7 +1164,7 @@ the ARN to split into its components.
 
 ---
 
-###### `arnFormat`<sup>Required</sup> <a name="arnFormat" id="aws-ddk-dev.CICDPipelineStack.splitArn.parameter.arnFormat"></a>
+###### `arnFormat`<sup>Required</sup> <a name="arnFormat" id="aws-ddk-core.CICDPipelineStack.splitArn.parameter.arnFormat"></a>
 
 - *Type:* aws-cdk-lib.ArnFormat
 
@@ -1085,7 +1172,7 @@ the expected format of 'arn' - depends on what format the service 'arn' represen
 
 ---
 
-##### `toJsonString` <a name="toJsonString" id="aws-ddk-dev.CICDPipelineStack.toJsonString"></a>
+##### `toJsonString` <a name="toJsonString" id="aws-ddk-core.CICDPipelineStack.toJsonString"></a>
 
 ```typescript
 public toJsonString(obj: any, space?: number): string
@@ -1093,109 +1180,109 @@ public toJsonString(obj: any, space?: number): string
 
 Convert an object, potentially containing tokens, to a JSON string.
 
-###### `obj`<sup>Required</sup> <a name="obj" id="aws-ddk-dev.CICDPipelineStack.toJsonString.parameter.obj"></a>
+###### `obj`<sup>Required</sup> <a name="obj" id="aws-ddk-core.CICDPipelineStack.toJsonString.parameter.obj"></a>
 
 - *Type:* any
 
 ---
 
-###### `space`<sup>Optional</sup> <a name="space" id="aws-ddk-dev.CICDPipelineStack.toJsonString.parameter.space"></a>
+###### `space`<sup>Optional</sup> <a name="space" id="aws-ddk-core.CICDPipelineStack.toJsonString.parameter.space"></a>
 
 - *Type:* number
 
 ---
 
-##### `addCustomStage` <a name="addCustomStage" id="aws-ddk-dev.CICDPipelineStack.addCustomStage"></a>
+##### `addCustomStage` <a name="addCustomStage" id="aws-ddk-core.CICDPipelineStack.addCustomStage"></a>
 
 ```typescript
 public addCustomStage(props: AddCustomStageProps): CICDPipelineStack
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.CICDPipelineStack.addCustomStage.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.CICDPipelineStack.addCustomStage.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AddCustomStageProps">AddCustomStageProps</a>
+- *Type:* <a href="#aws-ddk-core.AddCustomStageProps">AddCustomStageProps</a>
 
 ---
 
-##### `addNotifications` <a name="addNotifications" id="aws-ddk-dev.CICDPipelineStack.addNotifications"></a>
+##### `addNotifications` <a name="addNotifications" id="aws-ddk-core.CICDPipelineStack.addNotifications"></a>
 
 ```typescript
 public addNotifications(props: AddNotificationsProps): CICDPipelineStack
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.CICDPipelineStack.addNotifications.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.CICDPipelineStack.addNotifications.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AddNotificationsProps">AddNotificationsProps</a>
+- *Type:* <a href="#aws-ddk-core.AddNotificationsProps">AddNotificationsProps</a>
 
 ---
 
-##### `addSecurityLintStage` <a name="addSecurityLintStage" id="aws-ddk-dev.CICDPipelineStack.addSecurityLintStage"></a>
+##### `addSecurityLintStage` <a name="addSecurityLintStage" id="aws-ddk-core.CICDPipelineStack.addSecurityLintStage"></a>
 
 ```typescript
 public addSecurityLintStage(props: AddSecurityLintStageProps): CICDPipelineStack
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.CICDPipelineStack.addSecurityLintStage.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.CICDPipelineStack.addSecurityLintStage.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AddSecurityLintStageProps">AddSecurityLintStageProps</a>
+- *Type:* <a href="#aws-ddk-core.AddSecurityLintStageProps">AddSecurityLintStageProps</a>
 
 ---
 
-##### `addSourceAction` <a name="addSourceAction" id="aws-ddk-dev.CICDPipelineStack.addSourceAction"></a>
+##### `addSourceAction` <a name="addSourceAction" id="aws-ddk-core.CICDPipelineStack.addSourceAction"></a>
 
 ```typescript
 public addSourceAction(props: SourceActionProps): CICDPipelineStack
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.CICDPipelineStack.addSourceAction.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.CICDPipelineStack.addSourceAction.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.SourceActionProps">SourceActionProps</a>
+- *Type:* <a href="#aws-ddk-core.SourceActionProps">SourceActionProps</a>
 
 ---
 
-##### `addStage` <a name="addStage" id="aws-ddk-dev.CICDPipelineStack.addStage"></a>
+##### `addStage` <a name="addStage" id="aws-ddk-core.CICDPipelineStack.addStage"></a>
 
 ```typescript
 public addStage(props: AddApplicationStageProps): CICDPipelineStack
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.CICDPipelineStack.addStage.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.CICDPipelineStack.addStage.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AddApplicationStageProps">AddApplicationStageProps</a>
+- *Type:* <a href="#aws-ddk-core.AddApplicationStageProps">AddApplicationStageProps</a>
 
 ---
 
-##### `addSynthAction` <a name="addSynthAction" id="aws-ddk-dev.CICDPipelineStack.addSynthAction"></a>
+##### `addSynthAction` <a name="addSynthAction" id="aws-ddk-core.CICDPipelineStack.addSynthAction"></a>
 
 ```typescript
 public addSynthAction(props: SynthActionProps): CICDPipelineStack
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.CICDPipelineStack.addSynthAction.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.CICDPipelineStack.addSynthAction.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.SynthActionProps">SynthActionProps</a>
+- *Type:* <a href="#aws-ddk-core.SynthActionProps">SynthActionProps</a>
 
 ---
 
-##### `addTestStage` <a name="addTestStage" id="aws-ddk-dev.CICDPipelineStack.addTestStage"></a>
+##### `addTestStage` <a name="addTestStage" id="aws-ddk-core.CICDPipelineStack.addTestStage"></a>
 
 ```typescript
 public addTestStage(props: AddTestStageProps): CICDPipelineStack
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.CICDPipelineStack.addTestStage.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.CICDPipelineStack.addTestStage.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AddTestStageProps">AddTestStageProps</a>
+- *Type:* <a href="#aws-ddk-core.AddTestStageProps">AddTestStageProps</a>
 
 ---
 
-##### `buildPipeline` <a name="buildPipeline" id="aws-ddk-dev.CICDPipelineStack.buildPipeline"></a>
+##### `buildPipeline` <a name="buildPipeline" id="aws-ddk-core.CICDPipelineStack.buildPipeline"></a>
 
 ```typescript
 public buildPipeline(): CICDPipelineStack
 ```
 
-##### `synth` <a name="synth" id="aws-ddk-dev.CICDPipelineStack.synth"></a>
+##### `synth` <a name="synth" id="aws-ddk-core.CICDPipelineStack.synth"></a>
 
 ```typescript
 public synth(): CICDPipelineStack
@@ -1205,23 +1292,23 @@ public synth(): CICDPipelineStack
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.isStack">isStack</a></code> | Return whether the given object is a Stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.of">of</a></code> | Looks up the first stack scope in which `construct` is defined. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.isStack">isStack</a></code> | Return whether the given object is a Stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.of">of</a></code> | Looks up the first stack scope in which `construct` is defined. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-dev.CICDPipelineStack.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-core.CICDPipelineStack.isConstruct"></a>
 
 ```typescript
-import { CICDPipelineStack } from 'aws-ddk-dev'
+import { CICDPipelineStack } from 'aws-ddk-core'
 
 CICDPipelineStack.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.CICDPipelineStack.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.CICDPipelineStack.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -1229,10 +1316,10 @@ Any object.
 
 ---
 
-##### `isStack` <a name="isStack" id="aws-ddk-dev.CICDPipelineStack.isStack"></a>
+##### `isStack` <a name="isStack" id="aws-ddk-core.CICDPipelineStack.isStack"></a>
 
 ```typescript
-import { CICDPipelineStack } from 'aws-ddk-dev'
+import { CICDPipelineStack } from 'aws-ddk-core'
 
 CICDPipelineStack.isStack(x: any)
 ```
@@ -1241,16 +1328,16 @@ Return whether the given object is a Stack.
 
 We do attribute detection since we can't reliably use 'instanceof'.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.CICDPipelineStack.isStack.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.CICDPipelineStack.isStack.parameter.x"></a>
 
 - *Type:* any
 
 ---
 
-##### `of` <a name="of" id="aws-ddk-dev.CICDPipelineStack.of"></a>
+##### `of` <a name="of" id="aws-ddk-core.CICDPipelineStack.of"></a>
 
 ```typescript
-import { CICDPipelineStack } from 'aws-ddk-dev'
+import { CICDPipelineStack } from 'aws-ddk-core'
 
 CICDPipelineStack.of(construct: IConstruct)
 ```
@@ -1259,7 +1346,7 @@ Looks up the first stack scope in which `construct` is defined.
 
 Fails if there is no stack up the tree.
 
-###### `construct`<sup>Required</sup> <a name="construct" id="aws-ddk-dev.CICDPipelineStack.of.parameter.construct"></a>
+###### `construct`<sup>Required</sup> <a name="construct" id="aws-ddk-core.CICDPipelineStack.of.parameter.construct"></a>
 
 - *Type:* constructs.IConstruct
 
@@ -1271,38 +1358,39 @@ The construct to start the search from.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.account">account</a></code> | <code>string</code> | The AWS account into which this stack will be deployed. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.artifactId">artifactId</a></code> | <code>string</code> | The ID of the cloud assembly artifact for this stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.availabilityZones">availabilityZones</a></code> | <code>string[]</code> | Returns the list of AZs that are available in the AWS environment (account/region) associated with this stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.dependencies">dependencies</a></code> | <code>aws-cdk-lib.Stack[]</code> | Return the stacks this stack depends on. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.environment">environment</a></code> | <code>string</code> | The environment coordinates in which this stack is deployed. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.nested">nested</a></code> | <code>boolean</code> | Indicates if this is a nested stack, in which case `parentStack` will include a reference to it's parent. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.nestedStackParent">nestedStackParent</a></code> | <code>aws-cdk-lib.Stack</code> | If this is a nested stack, returns it's parent stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.nestedStackResource">nestedStackResource</a></code> | <code>aws-cdk-lib.CfnResource</code> | If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.notificationArns">notificationArns</a></code> | <code>string[]</code> | Returns the list of notification Amazon Resource Names (ARNs) for the current stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.partition">partition</a></code> | <code>string</code> | The partition in which this stack is defined. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.region">region</a></code> | <code>string</code> | The AWS region into which this stack will be deployed (e.g. `us-west-2`). |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.stackId">stackId</a></code> | <code>string</code> | The ID of the stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.stackName">stackName</a></code> | <code>string</code> | The concrete CloudFormation physical stack name. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method for this stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.tags">tags</a></code> | <code>aws-cdk-lib.TagManager</code> | Tags to be applied to the stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.templateFile">templateFile</a></code> | <code>string</code> | The name of the CloudFormation template file emitted to the output directory during synthesis. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.templateOptions">templateOptions</a></code> | <code>aws-cdk-lib.ITemplateOptions</code> | Options for CloudFormation template (like version, transform, description). |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether termination protection is enabled for this stack. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.urlSuffix">urlSuffix</a></code> | <code>string</code> | The Amazon domain suffix for the region in which this stack is defined. |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.environmentId">environmentId</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.pipelineId">pipelineId</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.pipelineName">pipelineName</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.notificationRule">notificationRule</a></code> | <code>aws-cdk-lib.aws_codestarnotifications.NotificationRule</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.pipeline">pipeline</a></code> | <code>aws-cdk-lib.pipelines.CodePipeline</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.pipelineKey">pipelineKey</a></code> | <code>constructs.IConstruct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.sourceAction">sourceAction</a></code> | <code>aws-cdk-lib.pipelines.CodePipelineSource</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CICDPipelineStack.property.synthAction">synthAction</a></code> | <code>aws-cdk-lib.pipelines.CodeBuildStep</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.account">account</a></code> | <code>string</code> | The AWS account into which this stack will be deployed. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.artifactId">artifactId</a></code> | <code>string</code> | The ID of the cloud assembly artifact for this stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.availabilityZones">availabilityZones</a></code> | <code>string[]</code> | Returns the list of AZs that are available in the AWS environment (account/region) associated with this stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.bundlingRequired">bundlingRequired</a></code> | <code>boolean</code> | Indicates whether the stack requires bundling or not. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.dependencies">dependencies</a></code> | <code>aws-cdk-lib.Stack[]</code> | Return the stacks this stack depends on. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.environment">environment</a></code> | <code>string</code> | The environment coordinates in which this stack is deployed. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.nested">nested</a></code> | <code>boolean</code> | Indicates if this is a nested stack, in which case `parentStack` will include a reference to it's parent. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.notificationArns">notificationArns</a></code> | <code>string[]</code> | Returns the list of notification Amazon Resource Names (ARNs) for the current stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.partition">partition</a></code> | <code>string</code> | The partition in which this stack is defined. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.region">region</a></code> | <code>string</code> | The AWS region into which this stack will be deployed (e.g. `us-west-2`). |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.stackId">stackId</a></code> | <code>string</code> | The ID of the stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.stackName">stackName</a></code> | <code>string</code> | The concrete CloudFormation physical stack name. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method for this stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.tags">tags</a></code> | <code>aws-cdk-lib.TagManager</code> | Tags to be applied to the stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.templateFile">templateFile</a></code> | <code>string</code> | The name of the CloudFormation template file emitted to the output directory during synthesis. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.templateOptions">templateOptions</a></code> | <code>aws-cdk-lib.ITemplateOptions</code> | Options for CloudFormation template (like version, transform, description). |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.urlSuffix">urlSuffix</a></code> | <code>string</code> | The Amazon domain suffix for the region in which this stack is defined. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.nestedStackParent">nestedStackParent</a></code> | <code>aws-cdk-lib.Stack</code> | If this is a nested stack, returns it's parent stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.nestedStackResource">nestedStackResource</a></code> | <code>aws-cdk-lib.CfnResource</code> | If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether termination protection is enabled for this stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.environmentId">environmentId</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipelineId">pipelineId</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipelineName">pipelineName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.notificationRule">notificationRule</a></code> | <code>aws-cdk-lib.aws_codestarnotifications.NotificationRule</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipeline">pipeline</a></code> | <code>aws-cdk-lib.pipelines.CodePipeline</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipelineKey">pipelineKey</a></code> | <code>constructs.IConstruct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.sourceAction">sourceAction</a></code> | <code>aws-cdk-lib.pipelines.CodePipelineSource</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.synthAction">synthAction</a></code> | <code>aws-cdk-lib.pipelines.CodeBuildStep</code> | *No description.* |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-dev.CICDPipelineStack.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-core.CICDPipelineStack.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -1314,7 +1402,7 @@ The tree node.
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="aws-ddk-dev.CICDPipelineStack.property.account"></a>
+##### `account`<sup>Required</sup> <a name="account" id="aws-ddk-core.CICDPipelineStack.property.account"></a>
 
 ```typescript
 public readonly account: string;
@@ -1343,7 +1431,7 @@ implement some other region-agnostic behavior.
 
 ---
 
-##### `artifactId`<sup>Required</sup> <a name="artifactId" id="aws-ddk-dev.CICDPipelineStack.property.artifactId"></a>
+##### `artifactId`<sup>Required</sup> <a name="artifactId" id="aws-ddk-core.CICDPipelineStack.property.artifactId"></a>
 
 ```typescript
 public readonly artifactId: string;
@@ -1355,7 +1443,7 @@ The ID of the cloud assembly artifact for this stack.
 
 ---
 
-##### `availabilityZones`<sup>Required</sup> <a name="availabilityZones" id="aws-ddk-dev.CICDPipelineStack.property.availabilityZones"></a>
+##### `availabilityZones`<sup>Required</sup> <a name="availabilityZones" id="aws-ddk-core.CICDPipelineStack.property.availabilityZones"></a>
 
 ```typescript
 public readonly availabilityZones: string[];
@@ -1378,7 +1466,19 @@ To specify a different strategy for selecting availability zones override this m
 
 ---
 
-##### `dependencies`<sup>Required</sup> <a name="dependencies" id="aws-ddk-dev.CICDPipelineStack.property.dependencies"></a>
+##### `bundlingRequired`<sup>Required</sup> <a name="bundlingRequired" id="aws-ddk-core.CICDPipelineStack.property.bundlingRequired"></a>
+
+```typescript
+public readonly bundlingRequired: boolean;
+```
+
+- *Type:* boolean
+
+Indicates whether the stack requires bundling or not.
+
+---
+
+##### `dependencies`<sup>Required</sup> <a name="dependencies" id="aws-ddk-core.CICDPipelineStack.property.dependencies"></a>
 
 ```typescript
 public readonly dependencies: Stack[];
@@ -1390,7 +1490,7 @@ Return the stacks this stack depends on.
 
 ---
 
-##### `environment`<sup>Required</sup> <a name="environment" id="aws-ddk-dev.CICDPipelineStack.property.environment"></a>
+##### `environment`<sup>Required</sup> <a name="environment" id="aws-ddk-core.CICDPipelineStack.property.environment"></a>
 
 ```typescript
 public readonly environment: string;
@@ -1414,7 +1514,7 @@ region/account-agnostic.
 
 ---
 
-##### `nested`<sup>Required</sup> <a name="nested" id="aws-ddk-dev.CICDPipelineStack.property.nested"></a>
+##### `nested`<sup>Required</sup> <a name="nested" id="aws-ddk-core.CICDPipelineStack.property.nested"></a>
 
 ```typescript
 public readonly nested: boolean;
@@ -1426,33 +1526,7 @@ Indicates if this is a nested stack, in which case `parentStack` will include a 
 
 ---
 
-##### `nestedStackParent`<sup>Optional</sup> <a name="nestedStackParent" id="aws-ddk-dev.CICDPipelineStack.property.nestedStackParent"></a>
-
-```typescript
-public readonly nestedStackParent: Stack;
-```
-
-- *Type:* aws-cdk-lib.Stack
-
-If this is a nested stack, returns it's parent stack.
-
----
-
-##### `nestedStackResource`<sup>Optional</sup> <a name="nestedStackResource" id="aws-ddk-dev.CICDPipelineStack.property.nestedStackResource"></a>
-
-```typescript
-public readonly nestedStackResource: CfnResource;
-```
-
-- *Type:* aws-cdk-lib.CfnResource
-
-If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource.
-
-`undefined` for top-level (non-nested) stacks.
-
----
-
-##### `notificationArns`<sup>Required</sup> <a name="notificationArns" id="aws-ddk-dev.CICDPipelineStack.property.notificationArns"></a>
+##### `notificationArns`<sup>Required</sup> <a name="notificationArns" id="aws-ddk-core.CICDPipelineStack.property.notificationArns"></a>
 
 ```typescript
 public readonly notificationArns: string[];
@@ -1464,7 +1538,7 @@ Returns the list of notification Amazon Resource Names (ARNs) for the current st
 
 ---
 
-##### `partition`<sup>Required</sup> <a name="partition" id="aws-ddk-dev.CICDPipelineStack.property.partition"></a>
+##### `partition`<sup>Required</sup> <a name="partition" id="aws-ddk-core.CICDPipelineStack.property.partition"></a>
 
 ```typescript
 public readonly partition: string;
@@ -1476,7 +1550,7 @@ The partition in which this stack is defined.
 
 ---
 
-##### `region`<sup>Required</sup> <a name="region" id="aws-ddk-dev.CICDPipelineStack.property.region"></a>
+##### `region`<sup>Required</sup> <a name="region" id="aws-ddk-core.CICDPipelineStack.property.region"></a>
 
 ```typescript
 public readonly region: string;
@@ -1505,7 +1579,7 @@ implement some other region-agnostic behavior.
 
 ---
 
-##### `stackId`<sup>Required</sup> <a name="stackId" id="aws-ddk-dev.CICDPipelineStack.property.stackId"></a>
+##### `stackId`<sup>Required</sup> <a name="stackId" id="aws-ddk-core.CICDPipelineStack.property.stackId"></a>
 
 ```typescript
 public readonly stackId: string;
@@ -1525,7 +1599,7 @@ The ID of the stack.
 ```
 
 
-##### `stackName`<sup>Required</sup> <a name="stackName" id="aws-ddk-dev.CICDPipelineStack.property.stackName"></a>
+##### `stackName`<sup>Required</sup> <a name="stackName" id="aws-ddk-core.CICDPipelineStack.property.stackName"></a>
 
 ```typescript
 public readonly stackName: string;
@@ -1546,7 +1620,7 @@ you can use `Aws.stackName` directly.
 
 ---
 
-##### `synthesizer`<sup>Required</sup> <a name="synthesizer" id="aws-ddk-dev.CICDPipelineStack.property.synthesizer"></a>
+##### `synthesizer`<sup>Required</sup> <a name="synthesizer" id="aws-ddk-core.CICDPipelineStack.property.synthesizer"></a>
 
 ```typescript
 public readonly synthesizer: IStackSynthesizer;
@@ -1558,7 +1632,7 @@ Synthesis method for this stack.
 
 ---
 
-##### `tags`<sup>Required</sup> <a name="tags" id="aws-ddk-dev.CICDPipelineStack.property.tags"></a>
+##### `tags`<sup>Required</sup> <a name="tags" id="aws-ddk-core.CICDPipelineStack.property.tags"></a>
 
 ```typescript
 public readonly tags: TagManager;
@@ -1570,7 +1644,7 @@ Tags to be applied to the stack.
 
 ---
 
-##### `templateFile`<sup>Required</sup> <a name="templateFile" id="aws-ddk-dev.CICDPipelineStack.property.templateFile"></a>
+##### `templateFile`<sup>Required</sup> <a name="templateFile" id="aws-ddk-core.CICDPipelineStack.property.templateFile"></a>
 
 ```typescript
 public readonly templateFile: string;
@@ -1584,7 +1658,7 @@ Example value: `MyStack.template.json`
 
 ---
 
-##### `templateOptions`<sup>Required</sup> <a name="templateOptions" id="aws-ddk-dev.CICDPipelineStack.property.templateOptions"></a>
+##### `templateOptions`<sup>Required</sup> <a name="templateOptions" id="aws-ddk-core.CICDPipelineStack.property.templateOptions"></a>
 
 ```typescript
 public readonly templateOptions: ITemplateOptions;
@@ -1596,19 +1670,7 @@ Options for CloudFormation template (like version, transform, description).
 
 ---
 
-##### `terminationProtection`<sup>Optional</sup> <a name="terminationProtection" id="aws-ddk-dev.CICDPipelineStack.property.terminationProtection"></a>
-
-```typescript
-public readonly terminationProtection: boolean;
-```
-
-- *Type:* boolean
-
-Whether termination protection is enabled for this stack.
-
----
-
-##### `urlSuffix`<sup>Required</sup> <a name="urlSuffix" id="aws-ddk-dev.CICDPipelineStack.property.urlSuffix"></a>
+##### `urlSuffix`<sup>Required</sup> <a name="urlSuffix" id="aws-ddk-core.CICDPipelineStack.property.urlSuffix"></a>
 
 ```typescript
 public readonly urlSuffix: string;
@@ -1620,7 +1682,45 @@ The Amazon domain suffix for the region in which this stack is defined.
 
 ---
 
-##### `environmentId`<sup>Optional</sup> <a name="environmentId" id="aws-ddk-dev.CICDPipelineStack.property.environmentId"></a>
+##### `nestedStackParent`<sup>Optional</sup> <a name="nestedStackParent" id="aws-ddk-core.CICDPipelineStack.property.nestedStackParent"></a>
+
+```typescript
+public readonly nestedStackParent: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+If this is a nested stack, returns it's parent stack.
+
+---
+
+##### `nestedStackResource`<sup>Optional</sup> <a name="nestedStackResource" id="aws-ddk-core.CICDPipelineStack.property.nestedStackResource"></a>
+
+```typescript
+public readonly nestedStackResource: CfnResource;
+```
+
+- *Type:* aws-cdk-lib.CfnResource
+
+If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource.
+
+`undefined` for top-level (non-nested) stacks.
+
+---
+
+##### `terminationProtection`<sup>Optional</sup> <a name="terminationProtection" id="aws-ddk-core.CICDPipelineStack.property.terminationProtection"></a>
+
+```typescript
+public readonly terminationProtection: boolean;
+```
+
+- *Type:* boolean
+
+Whether termination protection is enabled for this stack.
+
+---
+
+##### `environmentId`<sup>Optional</sup> <a name="environmentId" id="aws-ddk-core.CICDPipelineStack.property.environmentId"></a>
 
 ```typescript
 public readonly environmentId: string;
@@ -1630,7 +1730,7 @@ public readonly environmentId: string;
 
 ---
 
-##### `pipelineId`<sup>Optional</sup> <a name="pipelineId" id="aws-ddk-dev.CICDPipelineStack.property.pipelineId"></a>
+##### `pipelineId`<sup>Optional</sup> <a name="pipelineId" id="aws-ddk-core.CICDPipelineStack.property.pipelineId"></a>
 
 ```typescript
 public readonly pipelineId: string;
@@ -1640,7 +1740,7 @@ public readonly pipelineId: string;
 
 ---
 
-##### `pipelineName`<sup>Optional</sup> <a name="pipelineName" id="aws-ddk-dev.CICDPipelineStack.property.pipelineName"></a>
+##### `pipelineName`<sup>Optional</sup> <a name="pipelineName" id="aws-ddk-core.CICDPipelineStack.property.pipelineName"></a>
 
 ```typescript
 public readonly pipelineName: string;
@@ -1650,7 +1750,7 @@ public readonly pipelineName: string;
 
 ---
 
-##### `notificationRule`<sup>Optional</sup> <a name="notificationRule" id="aws-ddk-dev.CICDPipelineStack.property.notificationRule"></a>
+##### `notificationRule`<sup>Optional</sup> <a name="notificationRule" id="aws-ddk-core.CICDPipelineStack.property.notificationRule"></a>
 
 ```typescript
 public readonly notificationRule: NotificationRule;
@@ -1660,7 +1760,7 @@ public readonly notificationRule: NotificationRule;
 
 ---
 
-##### `pipeline`<sup>Optional</sup> <a name="pipeline" id="aws-ddk-dev.CICDPipelineStack.property.pipeline"></a>
+##### `pipeline`<sup>Optional</sup> <a name="pipeline" id="aws-ddk-core.CICDPipelineStack.property.pipeline"></a>
 
 ```typescript
 public readonly pipeline: CodePipeline;
@@ -1670,7 +1770,7 @@ public readonly pipeline: CodePipeline;
 
 ---
 
-##### `pipelineKey`<sup>Optional</sup> <a name="pipelineKey" id="aws-ddk-dev.CICDPipelineStack.property.pipelineKey"></a>
+##### `pipelineKey`<sup>Optional</sup> <a name="pipelineKey" id="aws-ddk-core.CICDPipelineStack.property.pipelineKey"></a>
 
 ```typescript
 public readonly pipelineKey: IConstruct;
@@ -1680,7 +1780,7 @@ public readonly pipelineKey: IConstruct;
 
 ---
 
-##### `sourceAction`<sup>Optional</sup> <a name="sourceAction" id="aws-ddk-dev.CICDPipelineStack.property.sourceAction"></a>
+##### `sourceAction`<sup>Optional</sup> <a name="sourceAction" id="aws-ddk-core.CICDPipelineStack.property.sourceAction"></a>
 
 ```typescript
 public readonly sourceAction: CodePipelineSource;
@@ -1690,7 +1790,7 @@ public readonly sourceAction: CodePipelineSource;
 
 ---
 
-##### `synthAction`<sup>Optional</sup> <a name="synthAction" id="aws-ddk-dev.CICDPipelineStack.property.synthAction"></a>
+##### `synthAction`<sup>Optional</sup> <a name="synthAction" id="aws-ddk-core.CICDPipelineStack.property.synthAction"></a>
 
 ```typescript
 public readonly synthAction: CodeBuildStep;
@@ -1701,39 +1801,39 @@ public readonly synthAction: CodeBuildStep;
 ---
 
 
-### DataPipeline <a name="DataPipeline" id="aws-ddk-dev.DataPipeline"></a>
+### DataPipeline <a name="DataPipeline" id="aws-ddk-core.DataPipeline"></a>
 
-#### Initializers <a name="Initializers" id="aws-ddk-dev.DataPipeline.Initializer"></a>
+#### Initializers <a name="Initializers" id="aws-ddk-core.DataPipeline.Initializer"></a>
 
 ```typescript
-import { DataPipeline } from 'aws-ddk-dev'
+import { DataPipeline } from 'aws-ddk-core'
 
 new DataPipeline(scope: Construct, id: string, props: DataPipelineProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.DataPipeline.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataPipeline.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataPipeline.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-dev.DataPipelineProps">DataPipelineProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipeline.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipeline.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipeline.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-core.DataPipelineProps">DataPipelineProps</a></code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-dev.DataPipeline.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-core.DataPipeline.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.DataPipeline.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.DataPipeline.Initializer.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.DataPipeline.Initializer.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.DataPipeline.Initializer.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.DataPipelineProps">DataPipelineProps</a>
+- *Type:* <a href="#aws-ddk-core.DataPipelineProps">DataPipelineProps</a>
 
 ---
 
@@ -1741,14 +1841,14 @@ new DataPipeline(scope: Construct, id: string, props: DataPipelineProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.DataPipeline.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#aws-ddk-dev.DataPipeline.addNotifications">addNotifications</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataPipeline.addRule">addRule</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataPipeline.addStage">addStage</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipeline.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-ddk-core.DataPipeline.addNotifications">addNotifications</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipeline.addRule">addRule</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipeline.addStage">addStage</a></code> | *No description.* |
 
 ---
 
-##### `toString` <a name="toString" id="aws-ddk-dev.DataPipeline.toString"></a>
+##### `toString` <a name="toString" id="aws-ddk-core.DataPipeline.toString"></a>
 
 ```typescript
 public toString(): string
@@ -1756,39 +1856,39 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addNotifications` <a name="addNotifications" id="aws-ddk-dev.DataPipeline.addNotifications"></a>
+##### `addNotifications` <a name="addNotifications" id="aws-ddk-core.DataPipeline.addNotifications"></a>
 
 ```typescript
 public addNotifications(notificationsTopic?: ITopic): DataPipeline
 ```
 
-###### `notificationsTopic`<sup>Optional</sup> <a name="notificationsTopic" id="aws-ddk-dev.DataPipeline.addNotifications.parameter.notificationsTopic"></a>
+###### `notificationsTopic`<sup>Optional</sup> <a name="notificationsTopic" id="aws-ddk-core.DataPipeline.addNotifications.parameter.notificationsTopic"></a>
 
 - *Type:* aws-cdk-lib.aws_sns.ITopic
 
 ---
 
-##### `addRule` <a name="addRule" id="aws-ddk-dev.DataPipeline.addRule"></a>
+##### `addRule` <a name="addRule" id="aws-ddk-core.DataPipeline.addRule"></a>
 
 ```typescript
 public addRule(props: AddRuleProps): DataPipeline
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.DataPipeline.addRule.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.DataPipeline.addRule.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AddRuleProps">AddRuleProps</a>
+- *Type:* <a href="#aws-ddk-core.AddRuleProps">AddRuleProps</a>
 
 ---
 
-##### `addStage` <a name="addStage" id="aws-ddk-dev.DataPipeline.addStage"></a>
+##### `addStage` <a name="addStage" id="aws-ddk-core.DataPipeline.addStage"></a>
 
 ```typescript
 public addStage(props: AddStageProps): DataPipeline
 ```
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.DataPipeline.addStage.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.DataPipeline.addStage.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AddStageProps">AddStageProps</a>
+- *Type:* <a href="#aws-ddk-core.AddStageProps">AddStageProps</a>
 
 ---
 
@@ -1796,21 +1896,21 @@ public addStage(props: AddStageProps): DataPipeline
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.DataPipeline.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-ddk-core.DataPipeline.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-dev.DataPipeline.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-core.DataPipeline.isConstruct"></a>
 
 ```typescript
-import { DataPipeline } from 'aws-ddk-dev'
+import { DataPipeline } from 'aws-ddk-core'
 
 DataPipeline.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.DataPipeline.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.DataPipeline.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -1822,13 +1922,13 @@ Any object.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.DataPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-ddk-dev.DataPipeline.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataPipeline.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-ddk-core.DataPipeline.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipeline.property.name">name</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-dev.DataPipeline.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-core.DataPipeline.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -1840,7 +1940,7 @@ The tree node.
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.DataPipeline.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.DataPipeline.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -1850,7 +1950,7 @@ public readonly description: string;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.DataPipeline.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.DataPipeline.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -1861,39 +1961,39 @@ public readonly name: string;
 ---
 
 
-### DataStage <a name="DataStage" id="aws-ddk-dev.DataStage"></a>
+### DataStage <a name="DataStage" id="aws-ddk-core.DataStage"></a>
 
-#### Initializers <a name="Initializers" id="aws-ddk-dev.DataStage.Initializer"></a>
+#### Initializers <a name="Initializers" id="aws-ddk-core.DataStage.Initializer"></a>
 
 ```typescript
-import { DataStage } from 'aws-ddk-dev'
+import { DataStage } from 'aws-ddk-core'
 
 new DataStage(scope: Construct, id: string, props: DataStageProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.DataStage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataStage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataStage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-dev.DataStageProps">DataStageProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-core.DataStageProps">DataStageProps</a></code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-dev.DataStage.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-core.DataStage.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.DataStage.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.DataStage.Initializer.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.DataStage.Initializer.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.DataStage.Initializer.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.DataStageProps">DataStageProps</a>
+- *Type:* <a href="#aws-ddk-core.DataStageProps">DataStageProps</a>
 
 ---
 
@@ -1901,12 +2001,12 @@ new DataStage(scope: Construct, id: string, props: DataStageProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.DataStage.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#aws-ddk-dev.DataStage.addAlarm">addAlarm</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-ddk-core.DataStage.addAlarm">addAlarm</a></code> | *No description.* |
 
 ---
 
-##### `toString` <a name="toString" id="aws-ddk-dev.DataStage.toString"></a>
+##### `toString` <a name="toString" id="aws-ddk-core.DataStage.toString"></a>
 
 ```typescript
 public toString(): string
@@ -1914,21 +2014,21 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addAlarm` <a name="addAlarm" id="aws-ddk-dev.DataStage.addAlarm"></a>
+##### `addAlarm` <a name="addAlarm" id="aws-ddk-core.DataStage.addAlarm"></a>
 
 ```typescript
 public addAlarm(id: string, props: AlarmProps): DataStage
 ```
 
-###### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.DataStage.addAlarm.parameter.id"></a>
+###### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.DataStage.addAlarm.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.DataStage.addAlarm.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.DataStage.addAlarm.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AlarmProps">AlarmProps</a>
+- *Type:* <a href="#aws-ddk-core.AlarmProps">AlarmProps</a>
 
 ---
 
@@ -1936,21 +2036,21 @@ public addAlarm(id: string, props: AlarmProps): DataStage
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.DataStage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-ddk-core.DataStage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-dev.DataStage.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-core.DataStage.isConstruct"></a>
 
 ```typescript
-import { DataStage } from 'aws-ddk-dev'
+import { DataStage } from 'aws-ddk-core'
 
 DataStage.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.DataStage.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.DataStage.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -1962,16 +2062,16 @@ Any object.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.DataStage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-ddk-dev.DataStage.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataStage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataStage.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataStage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataStage.property.cloudwatchAlarms">cloudwatchAlarms</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Alarm[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-ddk-core.DataStage.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStage.property.cloudwatchAlarms">cloudwatchAlarms</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Alarm[]</code> | *No description.* |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-dev.DataStage.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-core.DataStage.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -1983,7 +2083,7 @@ The tree node.
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.DataStage.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.DataStage.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -1993,7 +2093,7 @@ public readonly description: string;
 
 ---
 
-##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-dev.DataStage.property.eventPattern"></a>
+##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-core.DataStage.property.eventPattern"></a>
 
 ```typescript
 public readonly eventPattern: EventPattern;
@@ -2003,7 +2103,7 @@ public readonly eventPattern: EventPattern;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.DataStage.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.DataStage.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -2013,7 +2113,7 @@ public readonly name: string;
 
 ---
 
-##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-dev.DataStage.property.targets"></a>
+##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-core.DataStage.property.targets"></a>
 
 ```typescript
 public readonly targets: IRuleTarget[];
@@ -2023,7 +2123,7 @@ public readonly targets: IRuleTarget[];
 
 ---
 
-##### `cloudwatchAlarms`<sup>Required</sup> <a name="cloudwatchAlarms" id="aws-ddk-dev.DataStage.property.cloudwatchAlarms"></a>
+##### `cloudwatchAlarms`<sup>Required</sup> <a name="cloudwatchAlarms" id="aws-ddk-core.DataStage.property.cloudwatchAlarms"></a>
 
 ```typescript
 public readonly cloudwatchAlarms: Alarm[];
@@ -2034,39 +2134,39 @@ public readonly cloudwatchAlarms: Alarm[];
 ---
 
 
-### EventStage <a name="EventStage" id="aws-ddk-dev.EventStage"></a>
+### EventStage <a name="EventStage" id="aws-ddk-core.EventStage"></a>
 
-#### Initializers <a name="Initializers" id="aws-ddk-dev.EventStage.Initializer"></a>
+#### Initializers <a name="Initializers" id="aws-ddk-core.EventStage.Initializer"></a>
 
 ```typescript
-import { EventStage } from 'aws-ddk-dev'
+import { EventStage } from 'aws-ddk-core'
 
 new EventStage(scope: Construct, id: string, props: EventStageProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.EventStage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.EventStage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.EventStage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-dev.EventStageProps">EventStageProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-core.EventStageProps">EventStageProps</a></code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-dev.EventStage.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-core.EventStage.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.EventStage.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.EventStage.Initializer.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.EventStage.Initializer.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.EventStage.Initializer.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.EventStageProps">EventStageProps</a>
+- *Type:* <a href="#aws-ddk-core.EventStageProps">EventStageProps</a>
 
 ---
 
@@ -2074,11 +2174,11 @@ new EventStage(scope: Construct, id: string, props: EventStageProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.EventStage.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-ddk-core.EventStage.toString">toString</a></code> | Returns a string representation of this construct. |
 
 ---
 
-##### `toString` <a name="toString" id="aws-ddk-dev.EventStage.toString"></a>
+##### `toString` <a name="toString" id="aws-ddk-core.EventStage.toString"></a>
 
 ```typescript
 public toString(): string
@@ -2090,21 +2190,21 @@ Returns a string representation of this construct.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.EventStage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-ddk-core.EventStage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-dev.EventStage.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-core.EventStage.isConstruct"></a>
 
 ```typescript
-import { EventStage } from 'aws-ddk-dev'
+import { EventStage } from 'aws-ddk-core'
 
 EventStage.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.EventStage.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.EventStage.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -2116,15 +2216,15 @@ Any object.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.EventStage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-ddk-dev.EventStage.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.EventStage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.EventStage.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.EventStage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-ddk-core.EventStage.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStage.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-dev.EventStage.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-core.EventStage.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -2136,7 +2236,7 @@ The tree node.
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.EventStage.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.EventStage.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -2146,7 +2246,7 @@ public readonly description: string;
 
 ---
 
-##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-dev.EventStage.property.eventPattern"></a>
+##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-core.EventStage.property.eventPattern"></a>
 
 ```typescript
 public readonly eventPattern: EventPattern;
@@ -2156,7 +2256,7 @@ public readonly eventPattern: EventPattern;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.EventStage.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.EventStage.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -2166,7 +2266,7 @@ public readonly name: string;
 
 ---
 
-##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-dev.EventStage.property.targets"></a>
+##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-core.EventStage.property.targets"></a>
 
 ```typescript
 public readonly targets: IRuleTarget[];
@@ -2177,39 +2277,39 @@ public readonly targets: IRuleTarget[];
 ---
 
 
-### S3EventStage <a name="S3EventStage" id="aws-ddk-dev.S3EventStage"></a>
+### S3EventStage <a name="S3EventStage" id="aws-ddk-core.S3EventStage"></a>
 
-#### Initializers <a name="Initializers" id="aws-ddk-dev.S3EventStage.Initializer"></a>
+#### Initializers <a name="Initializers" id="aws-ddk-core.S3EventStage.Initializer"></a>
 
 ```typescript
-import { S3EventStage } from 'aws-ddk-dev'
+import { S3EventStage } from 'aws-ddk-core'
 
 new S3EventStage(scope: Construct, id: string, props: S3EventStageProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.S3EventStage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-dev.S3EventStageProps">S3EventStageProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-core.S3EventStageProps">S3EventStageProps</a></code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-dev.S3EventStage.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-core.S3EventStage.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.S3EventStage.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.S3EventStage.Initializer.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.S3EventStage.Initializer.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.S3EventStage.Initializer.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.S3EventStageProps">S3EventStageProps</a>
+- *Type:* <a href="#aws-ddk-core.S3EventStageProps">S3EventStageProps</a>
 
 ---
 
@@ -2217,11 +2317,11 @@ new S3EventStage(scope: Construct, id: string, props: S3EventStageProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.S3EventStage.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-ddk-core.S3EventStage.toString">toString</a></code> | Returns a string representation of this construct. |
 
 ---
 
-##### `toString` <a name="toString" id="aws-ddk-dev.S3EventStage.toString"></a>
+##### `toString` <a name="toString" id="aws-ddk-core.S3EventStage.toString"></a>
 
 ```typescript
 public toString(): string
@@ -2233,21 +2333,21 @@ Returns a string representation of this construct.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.S3EventStage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-ddk-core.S3EventStage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-dev.S3EventStage.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-core.S3EventStage.isConstruct"></a>
 
 ```typescript
-import { S3EventStage } from 'aws-ddk-dev'
+import { S3EventStage } from 'aws-ddk-core'
 
 S3EventStage.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.S3EventStage.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.S3EventStage.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -2259,16 +2359,16 @@ Any object.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.S3EventStage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-ddk-dev.S3EventStage.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStage.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStage.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-ddk-core.S3EventStage.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStage.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStage.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | *No description.* |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-dev.S3EventStage.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-core.S3EventStage.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -2280,7 +2380,7 @@ The tree node.
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.S3EventStage.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.S3EventStage.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -2290,7 +2390,7 @@ public readonly description: string;
 
 ---
 
-##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-dev.S3EventStage.property.eventPattern"></a>
+##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-core.S3EventStage.property.eventPattern"></a>
 
 ```typescript
 public readonly eventPattern: EventPattern;
@@ -2300,7 +2400,7 @@ public readonly eventPattern: EventPattern;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.S3EventStage.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.S3EventStage.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -2310,7 +2410,7 @@ public readonly name: string;
 
 ---
 
-##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-dev.S3EventStage.property.targets"></a>
+##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-core.S3EventStage.property.targets"></a>
 
 ```typescript
 public readonly targets: IRuleTarget[];
@@ -2320,7 +2420,7 @@ public readonly targets: IRuleTarget[];
 
 ---
 
-##### `bucket`<sup>Required</sup> <a name="bucket" id="aws-ddk-dev.S3EventStage.property.bucket"></a>
+##### `bucket`<sup>Required</sup> <a name="bucket" id="aws-ddk-core.S3EventStage.property.bucket"></a>
 
 ```typescript
 public readonly bucket: IBucket;
@@ -2331,39 +2431,39 @@ public readonly bucket: IBucket;
 ---
 
 
-### SqsToLambdaStage <a name="SqsToLambdaStage" id="aws-ddk-dev.SqsToLambdaStage"></a>
+### SqsToLambdaStage <a name="SqsToLambdaStage" id="aws-ddk-core.SqsToLambdaStage"></a>
 
-#### Initializers <a name="Initializers" id="aws-ddk-dev.SqsToLambdaStage.Initializer"></a>
+#### Initializers <a name="Initializers" id="aws-ddk-core.SqsToLambdaStage.Initializer"></a>
 
 ```typescript
-import { SqsToLambdaStage } from 'aws-ddk-dev'
+import { SqsToLambdaStage } from 'aws-ddk-core'
 
 new SqsToLambdaStage(scope: Construct, id: string, props: SqsToLambdaStageProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-dev.SqsToLambdaStageProps">SqsToLambdaStageProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-core.SqsToLambdaStageProps">SqsToLambdaStageProps</a></code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-dev.SqsToLambdaStage.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-core.SqsToLambdaStage.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.SqsToLambdaStage.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.SqsToLambdaStage.Initializer.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.SqsToLambdaStage.Initializer.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.SqsToLambdaStage.Initializer.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.SqsToLambdaStageProps">SqsToLambdaStageProps</a>
+- *Type:* <a href="#aws-ddk-core.SqsToLambdaStageProps">SqsToLambdaStageProps</a>
 
 ---
 
@@ -2371,12 +2471,12 @@ new SqsToLambdaStage(scope: Construct, id: string, props: SqsToLambdaStageProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.addAlarm">addAlarm</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.addAlarm">addAlarm</a></code> | *No description.* |
 
 ---
 
-##### `toString` <a name="toString" id="aws-ddk-dev.SqsToLambdaStage.toString"></a>
+##### `toString` <a name="toString" id="aws-ddk-core.SqsToLambdaStage.toString"></a>
 
 ```typescript
 public toString(): string
@@ -2384,21 +2484,21 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addAlarm` <a name="addAlarm" id="aws-ddk-dev.SqsToLambdaStage.addAlarm"></a>
+##### `addAlarm` <a name="addAlarm" id="aws-ddk-core.SqsToLambdaStage.addAlarm"></a>
 
 ```typescript
 public addAlarm(id: string, props: AlarmProps): DataStage
 ```
 
-###### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.SqsToLambdaStage.addAlarm.parameter.id"></a>
+###### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.SqsToLambdaStage.addAlarm.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.SqsToLambdaStage.addAlarm.parameter.props"></a>
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.SqsToLambdaStage.addAlarm.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.AlarmProps">AlarmProps</a>
+- *Type:* <a href="#aws-ddk-core.AlarmProps">AlarmProps</a>
 
 ---
 
@@ -2406,21 +2506,21 @@ public addAlarm(id: string, props: AlarmProps): DataStage
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-dev.SqsToLambdaStage.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-core.SqsToLambdaStage.isConstruct"></a>
 
 ```typescript
-import { SqsToLambdaStage } from 'aws-ddk-dev'
+import { SqsToLambdaStage } from 'aws-ddk-core'
 
 SqsToLambdaStage.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.SqsToLambdaStage.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.SqsToLambdaStage.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -2432,19 +2532,19 @@ Any object.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.cloudwatchAlarms">cloudwatchAlarms</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Alarm[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.function">function</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.queue">queue</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStage.property.deadLetterQueue">deadLetterQueue</a></code> | <code>aws-cdk-lib.aws_sqs.Queue</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.cloudwatchAlarms">cloudwatchAlarms</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Alarm[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.function">function</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.queue">queue</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStage.property.deadLetterQueue">deadLetterQueue</a></code> | <code>aws-cdk-lib.aws_sqs.Queue</code> | *No description.* |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-dev.SqsToLambdaStage.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-core.SqsToLambdaStage.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -2456,7 +2556,7 @@ The tree node.
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.SqsToLambdaStage.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.SqsToLambdaStage.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -2466,7 +2566,7 @@ public readonly description: string;
 
 ---
 
-##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-dev.SqsToLambdaStage.property.eventPattern"></a>
+##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-core.SqsToLambdaStage.property.eventPattern"></a>
 
 ```typescript
 public readonly eventPattern: EventPattern;
@@ -2476,7 +2576,7 @@ public readonly eventPattern: EventPattern;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.SqsToLambdaStage.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.SqsToLambdaStage.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -2486,7 +2586,7 @@ public readonly name: string;
 
 ---
 
-##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-dev.SqsToLambdaStage.property.targets"></a>
+##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-core.SqsToLambdaStage.property.targets"></a>
 
 ```typescript
 public readonly targets: IRuleTarget[];
@@ -2496,7 +2596,7 @@ public readonly targets: IRuleTarget[];
 
 ---
 
-##### `cloudwatchAlarms`<sup>Required</sup> <a name="cloudwatchAlarms" id="aws-ddk-dev.SqsToLambdaStage.property.cloudwatchAlarms"></a>
+##### `cloudwatchAlarms`<sup>Required</sup> <a name="cloudwatchAlarms" id="aws-ddk-core.SqsToLambdaStage.property.cloudwatchAlarms"></a>
 
 ```typescript
 public readonly cloudwatchAlarms: Alarm[];
@@ -2506,7 +2606,7 @@ public readonly cloudwatchAlarms: Alarm[];
 
 ---
 
-##### `function`<sup>Required</sup> <a name="function" id="aws-ddk-dev.SqsToLambdaStage.property.function"></a>
+##### `function`<sup>Required</sup> <a name="function" id="aws-ddk-core.SqsToLambdaStage.property.function"></a>
 
 ```typescript
 public readonly function: IFunction;
@@ -2516,7 +2616,7 @@ public readonly function: IFunction;
 
 ---
 
-##### `queue`<sup>Required</sup> <a name="queue" id="aws-ddk-dev.SqsToLambdaStage.property.queue"></a>
+##### `queue`<sup>Required</sup> <a name="queue" id="aws-ddk-core.SqsToLambdaStage.property.queue"></a>
 
 ```typescript
 public readonly queue: IQueue;
@@ -2526,7 +2626,7 @@ public readonly queue: IQueue;
 
 ---
 
-##### `deadLetterQueue`<sup>Optional</sup> <a name="deadLetterQueue" id="aws-ddk-dev.SqsToLambdaStage.property.deadLetterQueue"></a>
+##### `deadLetterQueue`<sup>Optional</sup> <a name="deadLetterQueue" id="aws-ddk-core.SqsToLambdaStage.property.deadLetterQueue"></a>
 
 ```typescript
 public readonly deadLetterQueue: Queue;
@@ -2537,39 +2637,39 @@ public readonly deadLetterQueue: Queue;
 ---
 
 
-### Stage <a name="Stage" id="aws-ddk-dev.Stage"></a>
+### Stage <a name="Stage" id="aws-ddk-core.Stage"></a>
 
-#### Initializers <a name="Initializers" id="aws-ddk-dev.Stage.Initializer"></a>
+#### Initializers <a name="Initializers" id="aws-ddk-core.Stage.Initializer"></a>
 
 ```typescript
-import { Stage } from 'aws-ddk-dev'
+import { Stage } from 'aws-ddk-core'
 
 new Stage(scope: Construct, id: string, props: StageProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.Stage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.Stage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.Stage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-dev.StageProps">StageProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.Stage.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.Stage.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.Stage.Initializer.parameter.props">props</a></code> | <code><a href="#aws-ddk-core.StageProps">StageProps</a></code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-dev.Stage.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-ddk-core.Stage.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-dev.Stage.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="aws-ddk-core.Stage.Initializer.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-dev.Stage.Initializer.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.Stage.Initializer.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-dev.StageProps">StageProps</a>
+- *Type:* <a href="#aws-ddk-core.StageProps">StageProps</a>
 
 ---
 
@@ -2577,11 +2677,11 @@ new Stage(scope: Construct, id: string, props: StageProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.Stage.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-ddk-core.Stage.toString">toString</a></code> | Returns a string representation of this construct. |
 
 ---
 
-##### `toString` <a name="toString" id="aws-ddk-dev.Stage.toString"></a>
+##### `toString` <a name="toString" id="aws-ddk-core.Stage.toString"></a>
 
 ```typescript
 public toString(): string
@@ -2593,21 +2693,21 @@ Returns a string representation of this construct.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-dev.Stage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-ddk-core.Stage.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-dev.Stage.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="aws-ddk-core.Stage.isConstruct"></a>
 
 ```typescript
-import { Stage } from 'aws-ddk-dev'
+import { Stage } from 'aws-ddk-core'
 
 Stage.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-dev.Stage.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-ddk-core.Stage.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -2619,15 +2719,15 @@ Any object.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.Stage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-ddk-dev.Stage.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.Stage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.Stage.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.Stage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.Stage.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-ddk-core.Stage.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.Stage.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
+| <code><a href="#aws-ddk-core.Stage.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.Stage.property.targets">targets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-dev.Stage.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-ddk-core.Stage.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -2639,7 +2739,7 @@ The tree node.
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.Stage.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.Stage.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -2649,7 +2749,7 @@ public readonly description: string;
 
 ---
 
-##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-dev.Stage.property.eventPattern"></a>
+##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-core.Stage.property.eventPattern"></a>
 
 ```typescript
 public readonly eventPattern: EventPattern;
@@ -2659,7 +2759,7 @@ public readonly eventPattern: EventPattern;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.Stage.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.Stage.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -2669,7 +2769,7 @@ public readonly name: string;
 
 ---
 
-##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-dev.Stage.property.targets"></a>
+##### `targets`<sup>Optional</sup> <a name="targets" id="aws-ddk-core.Stage.property.targets"></a>
 
 ```typescript
 public readonly targets: IRuleTarget[];
@@ -2682,12 +2782,12 @@ public readonly targets: IRuleTarget[];
 
 ## Structs <a name="Structs" id="Structs"></a>
 
-### AddApplicationStageProps <a name="AddApplicationStageProps" id="aws-ddk-dev.AddApplicationStageProps"></a>
+### AddApplicationStageProps <a name="AddApplicationStageProps" id="aws-ddk-core.AddApplicationStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.AddApplicationStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.AddApplicationStageProps.Initializer"></a>
 
 ```typescript
-import { AddApplicationStageProps } from 'aws-ddk-dev'
+import { AddApplicationStageProps } from 'aws-ddk-core'
 
 const addApplicationStageProps: AddApplicationStageProps = { ... }
 ```
@@ -2696,13 +2796,13 @@ const addApplicationStageProps: AddApplicationStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.AddApplicationStageProps.property.stage">stage</a></code> | <code>aws-cdk-lib.Stage</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddApplicationStageProps.property.stageId">stageId</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddApplicationStageProps.property.manualApprovals">manualApprovals</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddApplicationStageProps.property.stage">stage</a></code> | <code>aws-cdk-lib.Stage</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddApplicationStageProps.property.stageId">stageId</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddApplicationStageProps.property.manualApprovals">manualApprovals</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
-##### `stage`<sup>Required</sup> <a name="stage" id="aws-ddk-dev.AddApplicationStageProps.property.stage"></a>
+##### `stage`<sup>Required</sup> <a name="stage" id="aws-ddk-core.AddApplicationStageProps.property.stage"></a>
 
 ```typescript
 public readonly stage: Stage;
@@ -2712,7 +2812,7 @@ public readonly stage: Stage;
 
 ---
 
-##### `stageId`<sup>Required</sup> <a name="stageId" id="aws-ddk-dev.AddApplicationStageProps.property.stageId"></a>
+##### `stageId`<sup>Required</sup> <a name="stageId" id="aws-ddk-core.AddApplicationStageProps.property.stageId"></a>
 
 ```typescript
 public readonly stageId: string;
@@ -2722,7 +2822,7 @@ public readonly stageId: string;
 
 ---
 
-##### `manualApprovals`<sup>Optional</sup> <a name="manualApprovals" id="aws-ddk-dev.AddApplicationStageProps.property.manualApprovals"></a>
+##### `manualApprovals`<sup>Optional</sup> <a name="manualApprovals" id="aws-ddk-core.AddApplicationStageProps.property.manualApprovals"></a>
 
 ```typescript
 public readonly manualApprovals: boolean;
@@ -2732,12 +2832,12 @@ public readonly manualApprovals: boolean;
 
 ---
 
-### AddCustomStageProps <a name="AddCustomStageProps" id="aws-ddk-dev.AddCustomStageProps"></a>
+### AddCustomStageProps <a name="AddCustomStageProps" id="aws-ddk-core.AddCustomStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.AddCustomStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.AddCustomStageProps.Initializer"></a>
 
 ```typescript
-import { AddCustomStageProps } from 'aws-ddk-dev'
+import { AddCustomStageProps } from 'aws-ddk-core'
 
 const addCustomStageProps: AddCustomStageProps = { ... }
 ```
@@ -2746,12 +2846,12 @@ const addCustomStageProps: AddCustomStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.AddCustomStageProps.property.stageName">stageName</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddCustomStageProps.property.steps">steps</a></code> | <code>aws-cdk-lib.pipelines.Step[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddCustomStageProps.property.stageName">stageName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddCustomStageProps.property.steps">steps</a></code> | <code>aws-cdk-lib.pipelines.Step[]</code> | *No description.* |
 
 ---
 
-##### `stageName`<sup>Required</sup> <a name="stageName" id="aws-ddk-dev.AddCustomStageProps.property.stageName"></a>
+##### `stageName`<sup>Required</sup> <a name="stageName" id="aws-ddk-core.AddCustomStageProps.property.stageName"></a>
 
 ```typescript
 public readonly stageName: string;
@@ -2761,7 +2861,7 @@ public readonly stageName: string;
 
 ---
 
-##### `steps`<sup>Required</sup> <a name="steps" id="aws-ddk-dev.AddCustomStageProps.property.steps"></a>
+##### `steps`<sup>Required</sup> <a name="steps" id="aws-ddk-core.AddCustomStageProps.property.steps"></a>
 
 ```typescript
 public readonly steps: Step[];
@@ -2771,12 +2871,12 @@ public readonly steps: Step[];
 
 ---
 
-### AddNotificationsProps <a name="AddNotificationsProps" id="aws-ddk-dev.AddNotificationsProps"></a>
+### AddNotificationsProps <a name="AddNotificationsProps" id="aws-ddk-core.AddNotificationsProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.AddNotificationsProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.AddNotificationsProps.Initializer"></a>
 
 ```typescript
-import { AddNotificationsProps } from 'aws-ddk-dev'
+import { AddNotificationsProps } from 'aws-ddk-core'
 
 const addNotificationsProps: AddNotificationsProps = { ... }
 ```
@@ -2785,11 +2885,11 @@ const addNotificationsProps: AddNotificationsProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.AddNotificationsProps.property.notificationRule">notificationRule</a></code> | <code>aws-cdk-lib.aws_codestarnotifications.NotificationRule</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddNotificationsProps.property.notificationRule">notificationRule</a></code> | <code>aws-cdk-lib.aws_codestarnotifications.NotificationRule</code> | *No description.* |
 
 ---
 
-##### `notificationRule`<sup>Optional</sup> <a name="notificationRule" id="aws-ddk-dev.AddNotificationsProps.property.notificationRule"></a>
+##### `notificationRule`<sup>Optional</sup> <a name="notificationRule" id="aws-ddk-core.AddNotificationsProps.property.notificationRule"></a>
 
 ```typescript
 public readonly notificationRule: NotificationRule;
@@ -2799,12 +2899,12 @@ public readonly notificationRule: NotificationRule;
 
 ---
 
-### AddRuleProps <a name="AddRuleProps" id="aws-ddk-dev.AddRuleProps"></a>
+### AddRuleProps <a name="AddRuleProps" id="aws-ddk-core.AddRuleProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.AddRuleProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.AddRuleProps.Initializer"></a>
 
 ```typescript
-import { AddRuleProps } from 'aws-ddk-dev'
+import { AddRuleProps } from 'aws-ddk-core'
 
 const addRuleProps: AddRuleProps = { ... }
 ```
@@ -2813,14 +2913,14 @@ const addRuleProps: AddRuleProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.AddRuleProps.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddRuleProps.property.eventTargets">eventTargets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddRuleProps.property.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddRuleProps.property.overrideRule">overrideRule</a></code> | <code>aws-cdk-lib.aws_events.IRule</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddRuleProps.property.eventPattern">eventPattern</a></code> | <code>aws-cdk-lib.aws_events.EventPattern</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddRuleProps.property.eventTargets">eventTargets</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddRuleProps.property.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddRuleProps.property.overrideRule">overrideRule</a></code> | <code>aws-cdk-lib.aws_events.IRule</code> | *No description.* |
 
 ---
 
-##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-dev.AddRuleProps.property.eventPattern"></a>
+##### `eventPattern`<sup>Optional</sup> <a name="eventPattern" id="aws-ddk-core.AddRuleProps.property.eventPattern"></a>
 
 ```typescript
 public readonly eventPattern: EventPattern;
@@ -2830,7 +2930,7 @@ public readonly eventPattern: EventPattern;
 
 ---
 
-##### `eventTargets`<sup>Optional</sup> <a name="eventTargets" id="aws-ddk-dev.AddRuleProps.property.eventTargets"></a>
+##### `eventTargets`<sup>Optional</sup> <a name="eventTargets" id="aws-ddk-core.AddRuleProps.property.eventTargets"></a>
 
 ```typescript
 public readonly eventTargets: IRuleTarget[];
@@ -2840,7 +2940,7 @@ public readonly eventTargets: IRuleTarget[];
 
 ---
 
-##### `id`<sup>Optional</sup> <a name="id" id="aws-ddk-dev.AddRuleProps.property.id"></a>
+##### `id`<sup>Optional</sup> <a name="id" id="aws-ddk-core.AddRuleProps.property.id"></a>
 
 ```typescript
 public readonly id: string;
@@ -2850,7 +2950,7 @@ public readonly id: string;
 
 ---
 
-##### `overrideRule`<sup>Optional</sup> <a name="overrideRule" id="aws-ddk-dev.AddRuleProps.property.overrideRule"></a>
+##### `overrideRule`<sup>Optional</sup> <a name="overrideRule" id="aws-ddk-core.AddRuleProps.property.overrideRule"></a>
 
 ```typescript
 public readonly overrideRule: IRule;
@@ -2860,12 +2960,12 @@ public readonly overrideRule: IRule;
 
 ---
 
-### AddSecurityLintStageProps <a name="AddSecurityLintStageProps" id="aws-ddk-dev.AddSecurityLintStageProps"></a>
+### AddSecurityLintStageProps <a name="AddSecurityLintStageProps" id="aws-ddk-core.AddSecurityLintStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.AddSecurityLintStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.AddSecurityLintStageProps.Initializer"></a>
 
 ```typescript
-import { AddSecurityLintStageProps } from 'aws-ddk-dev'
+import { AddSecurityLintStageProps } from 'aws-ddk-core'
 
 const addSecurityLintStageProps: AddSecurityLintStageProps = { ... }
 ```
@@ -2874,12 +2974,12 @@ const addSecurityLintStageProps: AddSecurityLintStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.AddSecurityLintStageProps.property.cloudAssemblyFileSet">cloudAssemblyFileSet</a></code> | <code>aws-cdk-lib.pipelines.IFileSetProducer</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddSecurityLintStageProps.property.stageName">stageName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddSecurityLintStageProps.property.cloudAssemblyFileSet">cloudAssemblyFileSet</a></code> | <code>aws-cdk-lib.pipelines.IFileSetProducer</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddSecurityLintStageProps.property.stageName">stageName</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `cloudAssemblyFileSet`<sup>Optional</sup> <a name="cloudAssemblyFileSet" id="aws-ddk-dev.AddSecurityLintStageProps.property.cloudAssemblyFileSet"></a>
+##### `cloudAssemblyFileSet`<sup>Optional</sup> <a name="cloudAssemblyFileSet" id="aws-ddk-core.AddSecurityLintStageProps.property.cloudAssemblyFileSet"></a>
 
 ```typescript
 public readonly cloudAssemblyFileSet: IFileSetProducer;
@@ -2889,7 +2989,7 @@ public readonly cloudAssemblyFileSet: IFileSetProducer;
 
 ---
 
-##### `stageName`<sup>Optional</sup> <a name="stageName" id="aws-ddk-dev.AddSecurityLintStageProps.property.stageName"></a>
+##### `stageName`<sup>Optional</sup> <a name="stageName" id="aws-ddk-core.AddSecurityLintStageProps.property.stageName"></a>
 
 ```typescript
 public readonly stageName: string;
@@ -2899,12 +2999,12 @@ public readonly stageName: string;
 
 ---
 
-### AddStageProps <a name="AddStageProps" id="aws-ddk-dev.AddStageProps"></a>
+### AddStageProps <a name="AddStageProps" id="aws-ddk-core.AddStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.AddStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.AddStageProps.Initializer"></a>
 
 ```typescript
-import { AddStageProps } from 'aws-ddk-dev'
+import { AddStageProps } from 'aws-ddk-core'
 
 const addStageProps: AddStageProps = { ... }
 ```
@@ -2913,23 +3013,23 @@ const addStageProps: AddStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.AddStageProps.property.stage">stage</a></code> | <code><a href="#aws-ddk-dev.Stage">Stage</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddStageProps.property.overrideRule">overrideRule</a></code> | <code>aws-cdk-lib.aws_events.IRule</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddStageProps.property.skipRule">skipRule</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddStageProps.property.stage">stage</a></code> | <code><a href="#aws-ddk-core.Stage">Stage</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddStageProps.property.overrideRule">overrideRule</a></code> | <code>aws-cdk-lib.aws_events.IRule</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddStageProps.property.skipRule">skipRule</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
-##### `stage`<sup>Required</sup> <a name="stage" id="aws-ddk-dev.AddStageProps.property.stage"></a>
+##### `stage`<sup>Required</sup> <a name="stage" id="aws-ddk-core.AddStageProps.property.stage"></a>
 
 ```typescript
 public readonly stage: Stage;
 ```
 
-- *Type:* <a href="#aws-ddk-dev.Stage">Stage</a>
+- *Type:* <a href="#aws-ddk-core.Stage">Stage</a>
 
 ---
 
-##### `overrideRule`<sup>Optional</sup> <a name="overrideRule" id="aws-ddk-dev.AddStageProps.property.overrideRule"></a>
+##### `overrideRule`<sup>Optional</sup> <a name="overrideRule" id="aws-ddk-core.AddStageProps.property.overrideRule"></a>
 
 ```typescript
 public readonly overrideRule: IRule;
@@ -2939,7 +3039,7 @@ public readonly overrideRule: IRule;
 
 ---
 
-##### `skipRule`<sup>Optional</sup> <a name="skipRule" id="aws-ddk-dev.AddStageProps.property.skipRule"></a>
+##### `skipRule`<sup>Optional</sup> <a name="skipRule" id="aws-ddk-core.AddStageProps.property.skipRule"></a>
 
 ```typescript
 public readonly skipRule: boolean;
@@ -2949,12 +3049,12 @@ public readonly skipRule: boolean;
 
 ---
 
-### AddTestStageProps <a name="AddTestStageProps" id="aws-ddk-dev.AddTestStageProps"></a>
+### AddTestStageProps <a name="AddTestStageProps" id="aws-ddk-core.AddTestStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.AddTestStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.AddTestStageProps.Initializer"></a>
 
 ```typescript
-import { AddTestStageProps } from 'aws-ddk-dev'
+import { AddTestStageProps } from 'aws-ddk-core'
 
 const addTestStageProps: AddTestStageProps = { ... }
 ```
@@ -2963,13 +3063,13 @@ const addTestStageProps: AddTestStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.AddTestStageProps.property.cloudAssemblyFileSet">cloudAssemblyFileSet</a></code> | <code>aws-cdk-lib.pipelines.IFileSetProducer</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddTestStageProps.property.commands">commands</a></code> | <code>string[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AddTestStageProps.property.stageName">stageName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddTestStageProps.property.cloudAssemblyFileSet">cloudAssemblyFileSet</a></code> | <code>aws-cdk-lib.pipelines.IFileSetProducer</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddTestStageProps.property.commands">commands</a></code> | <code>string[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AddTestStageProps.property.stageName">stageName</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `cloudAssemblyFileSet`<sup>Optional</sup> <a name="cloudAssemblyFileSet" id="aws-ddk-dev.AddTestStageProps.property.cloudAssemblyFileSet"></a>
+##### `cloudAssemblyFileSet`<sup>Optional</sup> <a name="cloudAssemblyFileSet" id="aws-ddk-core.AddTestStageProps.property.cloudAssemblyFileSet"></a>
 
 ```typescript
 public readonly cloudAssemblyFileSet: IFileSetProducer;
@@ -2979,7 +3079,7 @@ public readonly cloudAssemblyFileSet: IFileSetProducer;
 
 ---
 
-##### `commands`<sup>Optional</sup> <a name="commands" id="aws-ddk-dev.AddTestStageProps.property.commands"></a>
+##### `commands`<sup>Optional</sup> <a name="commands" id="aws-ddk-core.AddTestStageProps.property.commands"></a>
 
 ```typescript
 public readonly commands: string[];
@@ -2989,7 +3089,7 @@ public readonly commands: string[];
 
 ---
 
-##### `stageName`<sup>Optional</sup> <a name="stageName" id="aws-ddk-dev.AddTestStageProps.property.stageName"></a>
+##### `stageName`<sup>Optional</sup> <a name="stageName" id="aws-ddk-core.AddTestStageProps.property.stageName"></a>
 
 ```typescript
 public readonly stageName: string;
@@ -2999,12 +3099,12 @@ public readonly stageName: string;
 
 ---
 
-### AlarmProps <a name="AlarmProps" id="aws-ddk-dev.AlarmProps"></a>
+### AlarmProps <a name="AlarmProps" id="aws-ddk-core.AlarmProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.AlarmProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.AlarmProps.Initializer"></a>
 
 ```typescript
-import { AlarmProps } from 'aws-ddk-dev'
+import { AlarmProps } from 'aws-ddk-core'
 
 const alarmProps: AlarmProps = { ... }
 ```
@@ -3013,14 +3113,14 @@ const alarmProps: AlarmProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.AlarmProps.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IMetric</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AlarmProps.property.comparisonOperator">comparisonOperator</a></code> | <code>aws-cdk-lib.aws_cloudwatch.ComparisonOperator</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AlarmProps.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.AlarmProps.property.threshold">threshold</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AlarmProps.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IMetric</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AlarmProps.property.comparisonOperator">comparisonOperator</a></code> | <code>aws-cdk-lib.aws_cloudwatch.ComparisonOperator</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AlarmProps.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AlarmProps.property.threshold">threshold</a></code> | <code>number</code> | *No description.* |
 
 ---
 
-##### `metric`<sup>Required</sup> <a name="metric" id="aws-ddk-dev.AlarmProps.property.metric"></a>
+##### `metric`<sup>Required</sup> <a name="metric" id="aws-ddk-core.AlarmProps.property.metric"></a>
 
 ```typescript
 public readonly metric: IMetric;
@@ -3030,7 +3130,7 @@ public readonly metric: IMetric;
 
 ---
 
-##### `comparisonOperator`<sup>Optional</sup> <a name="comparisonOperator" id="aws-ddk-dev.AlarmProps.property.comparisonOperator"></a>
+##### `comparisonOperator`<sup>Optional</sup> <a name="comparisonOperator" id="aws-ddk-core.AlarmProps.property.comparisonOperator"></a>
 
 ```typescript
 public readonly comparisonOperator: ComparisonOperator;
@@ -3040,7 +3140,7 @@ public readonly comparisonOperator: ComparisonOperator;
 
 ---
 
-##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="aws-ddk-dev.AlarmProps.property.evaluationPeriods"></a>
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="aws-ddk-core.AlarmProps.property.evaluationPeriods"></a>
 
 ```typescript
 public readonly evaluationPeriods: number;
@@ -3050,7 +3150,7 @@ public readonly evaluationPeriods: number;
 
 ---
 
-##### `threshold`<sup>Optional</sup> <a name="threshold" id="aws-ddk-dev.AlarmProps.property.threshold"></a>
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="aws-ddk-core.AlarmProps.property.threshold"></a>
 
 ```typescript
 public readonly threshold: number;
@@ -3060,12 +3160,12 @@ public readonly threshold: number;
 
 ---
 
-### BaseStackProps <a name="BaseStackProps" id="aws-ddk-dev.BaseStackProps"></a>
+### BaseStackProps <a name="BaseStackProps" id="aws-ddk-core.BaseStackProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.BaseStackProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.BaseStackProps.Initializer"></a>
 
 ```typescript
-import { BaseStackProps } from 'aws-ddk-dev'
+import { BaseStackProps } from 'aws-ddk-core'
 
 const baseStackProps: BaseStackProps = { ... }
 ```
@@ -3074,18 +3174,18 @@ const baseStackProps: BaseStackProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.BaseStackProps.property.analyticsReporting">analyticsReporting</a></code> | <code>boolean</code> | Include runtime versioning information in this Stack. |
-| <code><a href="#aws-ddk-dev.BaseStackProps.property.description">description</a></code> | <code>string</code> | A description of the stack. |
-| <code><a href="#aws-ddk-dev.BaseStackProps.property.env">env</a></code> | <code>aws-cdk-lib.Environment</code> | The AWS environment (account/region) where this stack will be deployed. |
-| <code><a href="#aws-ddk-dev.BaseStackProps.property.stackName">stackName</a></code> | <code>string</code> | Name to deploy the stack with. |
-| <code><a href="#aws-ddk-dev.BaseStackProps.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method to use while deploying this stack. |
-| <code><a href="#aws-ddk-dev.BaseStackProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Stack tags that will be applied to all the taggable resources and the stack itself. |
-| <code><a href="#aws-ddk-dev.BaseStackProps.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether to enable termination protection for this stack. |
-| <code><a href="#aws-ddk-dev.BaseStackProps.property.permissionBoundaryArn">permissionBoundaryArn</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.analyticsReporting">analyticsReporting</a></code> | <code>boolean</code> | Include runtime versioning information in this Stack. |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.description">description</a></code> | <code>string</code> | A description of the stack. |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.env">env</a></code> | <code>aws-cdk-lib.Environment</code> | The AWS environment (account/region) where this stack will be deployed. |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.stackName">stackName</a></code> | <code>string</code> | Name to deploy the stack with. |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method to use while deploying this stack. |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Stack tags that will be applied to all the taggable resources and the stack itself. |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether to enable termination protection for this stack. |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.permissionBoundaryArn">permissionBoundaryArn</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `analyticsReporting`<sup>Optional</sup> <a name="analyticsReporting" id="aws-ddk-dev.BaseStackProps.property.analyticsReporting"></a>
+##### `analyticsReporting`<sup>Optional</sup> <a name="analyticsReporting" id="aws-ddk-core.BaseStackProps.property.analyticsReporting"></a>
 
 ```typescript
 public readonly analyticsReporting: boolean;
@@ -3098,7 +3198,7 @@ Include runtime versioning information in this Stack.
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.BaseStackProps.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.BaseStackProps.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -3111,7 +3211,7 @@ A description of the stack.
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="env" id="aws-ddk-dev.BaseStackProps.property.env"></a>
+##### `env`<sup>Optional</sup> <a name="env" id="aws-ddk-core.BaseStackProps.property.env"></a>
 
 ```typescript
 public readonly env: Environment;
@@ -3185,7 +3285,7 @@ new MyStack(app, 'Stack1');
 ```
 
 
-##### `stackName`<sup>Optional</sup> <a name="stackName" id="aws-ddk-dev.BaseStackProps.property.stackName"></a>
+##### `stackName`<sup>Optional</sup> <a name="stackName" id="aws-ddk-core.BaseStackProps.property.stackName"></a>
 
 ```typescript
 public readonly stackName: string;
@@ -3198,7 +3298,7 @@ Name to deploy the stack with.
 
 ---
 
-##### `synthesizer`<sup>Optional</sup> <a name="synthesizer" id="aws-ddk-dev.BaseStackProps.property.synthesizer"></a>
+##### `synthesizer`<sup>Optional</sup> <a name="synthesizer" id="aws-ddk-core.BaseStackProps.property.synthesizer"></a>
 
 ```typescript
 public readonly synthesizer: IStackSynthesizer;
@@ -3211,7 +3311,7 @@ Synthesis method to use while deploying this stack.
 
 ---
 
-##### `tags`<sup>Optional</sup> <a name="tags" id="aws-ddk-dev.BaseStackProps.property.tags"></a>
+##### `tags`<sup>Optional</sup> <a name="tags" id="aws-ddk-core.BaseStackProps.property.tags"></a>
 
 ```typescript
 public readonly tags: {[ key: string ]: string};
@@ -3224,7 +3324,7 @@ Stack tags that will be applied to all the taggable resources and the stack itse
 
 ---
 
-##### `terminationProtection`<sup>Optional</sup> <a name="terminationProtection" id="aws-ddk-dev.BaseStackProps.property.terminationProtection"></a>
+##### `terminationProtection`<sup>Optional</sup> <a name="terminationProtection" id="aws-ddk-core.BaseStackProps.property.terminationProtection"></a>
 
 ```typescript
 public readonly terminationProtection: boolean;
@@ -3237,7 +3337,7 @@ Whether to enable termination protection for this stack.
 
 ---
 
-##### `permissionBoundaryArn`<sup>Optional</sup> <a name="permissionBoundaryArn" id="aws-ddk-dev.BaseStackProps.property.permissionBoundaryArn"></a>
+##### `permissionBoundaryArn`<sup>Optional</sup> <a name="permissionBoundaryArn" id="aws-ddk-core.BaseStackProps.property.permissionBoundaryArn"></a>
 
 ```typescript
 public readonly permissionBoundaryArn: string;
@@ -3247,12 +3347,12 @@ public readonly permissionBoundaryArn: string;
 
 ---
 
-### CodeArtifactPublishActionProps <a name="CodeArtifactPublishActionProps" id="aws-ddk-dev.CodeArtifactPublishActionProps"></a>
+### CodeArtifactPublishActionProps <a name="CodeArtifactPublishActionProps" id="aws-ddk-core.CodeArtifactPublishActionProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.CodeArtifactPublishActionProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.CodeArtifactPublishActionProps.Initializer"></a>
 
 ```typescript
-import { CodeArtifactPublishActionProps } from 'aws-ddk-dev'
+import { CodeArtifactPublishActionProps } from 'aws-ddk-core'
 
 const codeArtifactPublishActionProps: CodeArtifactPublishActionProps = { ... }
 ```
@@ -3261,18 +3361,18 @@ const codeArtifactPublishActionProps: CodeArtifactPublishActionProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.CodeArtifactPublishActionProps.property.account">account</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeArtifactPublishActionProps.property.codeartifactDomain">codeartifactDomain</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeArtifactPublishActionProps.property.codeartifactDomainOwner">codeartifactDomainOwner</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeArtifactPublishActionProps.property.codeartifactRepository">codeartifactRepository</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeArtifactPublishActionProps.property.partition">partition</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeArtifactPublishActionProps.property.region">region</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeArtifactPublishActionProps.property.codePipelineSource">codePipelineSource</a></code> | <code>aws-cdk-lib.pipelines.CodePipelineSource</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeArtifactPublishActionProps.property.rolePolicyStatements">rolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeArtifactPublishActionProps.property.account">account</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeArtifactPublishActionProps.property.codeartifactDomain">codeartifactDomain</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeArtifactPublishActionProps.property.codeartifactDomainOwner">codeartifactDomainOwner</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeArtifactPublishActionProps.property.codeartifactRepository">codeartifactRepository</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeArtifactPublishActionProps.property.partition">partition</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeArtifactPublishActionProps.property.region">region</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeArtifactPublishActionProps.property.codePipelineSource">codePipelineSource</a></code> | <code>aws-cdk-lib.pipelines.CodePipelineSource</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeArtifactPublishActionProps.property.rolePolicyStatements">rolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | *No description.* |
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="aws-ddk-dev.CodeArtifactPublishActionProps.property.account"></a>
+##### `account`<sup>Required</sup> <a name="account" id="aws-ddk-core.CodeArtifactPublishActionProps.property.account"></a>
 
 ```typescript
 public readonly account: string;
@@ -3282,7 +3382,7 @@ public readonly account: string;
 
 ---
 
-##### `codeartifactDomain`<sup>Required</sup> <a name="codeartifactDomain" id="aws-ddk-dev.CodeArtifactPublishActionProps.property.codeartifactDomain"></a>
+##### `codeartifactDomain`<sup>Required</sup> <a name="codeartifactDomain" id="aws-ddk-core.CodeArtifactPublishActionProps.property.codeartifactDomain"></a>
 
 ```typescript
 public readonly codeartifactDomain: string;
@@ -3292,7 +3392,7 @@ public readonly codeartifactDomain: string;
 
 ---
 
-##### `codeartifactDomainOwner`<sup>Required</sup> <a name="codeartifactDomainOwner" id="aws-ddk-dev.CodeArtifactPublishActionProps.property.codeartifactDomainOwner"></a>
+##### `codeartifactDomainOwner`<sup>Required</sup> <a name="codeartifactDomainOwner" id="aws-ddk-core.CodeArtifactPublishActionProps.property.codeartifactDomainOwner"></a>
 
 ```typescript
 public readonly codeartifactDomainOwner: string;
@@ -3302,7 +3402,7 @@ public readonly codeartifactDomainOwner: string;
 
 ---
 
-##### `codeartifactRepository`<sup>Required</sup> <a name="codeartifactRepository" id="aws-ddk-dev.CodeArtifactPublishActionProps.property.codeartifactRepository"></a>
+##### `codeartifactRepository`<sup>Required</sup> <a name="codeartifactRepository" id="aws-ddk-core.CodeArtifactPublishActionProps.property.codeartifactRepository"></a>
 
 ```typescript
 public readonly codeartifactRepository: string;
@@ -3312,7 +3412,7 @@ public readonly codeartifactRepository: string;
 
 ---
 
-##### `partition`<sup>Required</sup> <a name="partition" id="aws-ddk-dev.CodeArtifactPublishActionProps.property.partition"></a>
+##### `partition`<sup>Required</sup> <a name="partition" id="aws-ddk-core.CodeArtifactPublishActionProps.property.partition"></a>
 
 ```typescript
 public readonly partition: string;
@@ -3322,7 +3422,7 @@ public readonly partition: string;
 
 ---
 
-##### `region`<sup>Required</sup> <a name="region" id="aws-ddk-dev.CodeArtifactPublishActionProps.property.region"></a>
+##### `region`<sup>Required</sup> <a name="region" id="aws-ddk-core.CodeArtifactPublishActionProps.property.region"></a>
 
 ```typescript
 public readonly region: string;
@@ -3332,7 +3432,7 @@ public readonly region: string;
 
 ---
 
-##### `codePipelineSource`<sup>Optional</sup> <a name="codePipelineSource" id="aws-ddk-dev.CodeArtifactPublishActionProps.property.codePipelineSource"></a>
+##### `codePipelineSource`<sup>Optional</sup> <a name="codePipelineSource" id="aws-ddk-core.CodeArtifactPublishActionProps.property.codePipelineSource"></a>
 
 ```typescript
 public readonly codePipelineSource: CodePipelineSource;
@@ -3342,7 +3442,7 @@ public readonly codePipelineSource: CodePipelineSource;
 
 ---
 
-##### `rolePolicyStatements`<sup>Optional</sup> <a name="rolePolicyStatements" id="aws-ddk-dev.CodeArtifactPublishActionProps.property.rolePolicyStatements"></a>
+##### `rolePolicyStatements`<sup>Optional</sup> <a name="rolePolicyStatements" id="aws-ddk-core.CodeArtifactPublishActionProps.property.rolePolicyStatements"></a>
 
 ```typescript
 public readonly rolePolicyStatements: PolicyStatement[];
@@ -3352,12 +3452,12 @@ public readonly rolePolicyStatements: PolicyStatement[];
 
 ---
 
-### CodeCommitSourceActionProps <a name="CodeCommitSourceActionProps" id="aws-ddk-dev.CodeCommitSourceActionProps"></a>
+### CodeCommitSourceActionProps <a name="CodeCommitSourceActionProps" id="aws-ddk-core.CodeCommitSourceActionProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.CodeCommitSourceActionProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.CodeCommitSourceActionProps.Initializer"></a>
 
 ```typescript
-import { CodeCommitSourceActionProps } from 'aws-ddk-dev'
+import { CodeCommitSourceActionProps } from 'aws-ddk-core'
 
 const codeCommitSourceActionProps: CodeCommitSourceActionProps = { ... }
 ```
@@ -3366,13 +3466,13 @@ const codeCommitSourceActionProps: CodeCommitSourceActionProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.CodeCommitSourceActionProps.property.branch">branch</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeCommitSourceActionProps.property.repositoryName">repositoryName</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.CodeCommitSourceActionProps.property.props">props</a></code> | <code>aws-cdk-lib.pipelines.ConnectionSourceOptions</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeCommitSourceActionProps.property.branch">branch</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeCommitSourceActionProps.property.repositoryName">repositoryName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CodeCommitSourceActionProps.property.props">props</a></code> | <code>aws-cdk-lib.pipelines.ConnectionSourceOptions</code> | *No description.* |
 
 ---
 
-##### `branch`<sup>Required</sup> <a name="branch" id="aws-ddk-dev.CodeCommitSourceActionProps.property.branch"></a>
+##### `branch`<sup>Required</sup> <a name="branch" id="aws-ddk-core.CodeCommitSourceActionProps.property.branch"></a>
 
 ```typescript
 public readonly branch: string;
@@ -3382,7 +3482,7 @@ public readonly branch: string;
 
 ---
 
-##### `repositoryName`<sup>Required</sup> <a name="repositoryName" id="aws-ddk-dev.CodeCommitSourceActionProps.property.repositoryName"></a>
+##### `repositoryName`<sup>Required</sup> <a name="repositoryName" id="aws-ddk-core.CodeCommitSourceActionProps.property.repositoryName"></a>
 
 ```typescript
 public readonly repositoryName: string;
@@ -3392,7 +3492,7 @@ public readonly repositoryName: string;
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="props" id="aws-ddk-dev.CodeCommitSourceActionProps.property.props"></a>
+##### `props`<sup>Optional</sup> <a name="props" id="aws-ddk-core.CodeCommitSourceActionProps.property.props"></a>
 
 ```typescript
 public readonly props: ConnectionSourceOptions;
@@ -3402,12 +3502,12 @@ public readonly props: ConnectionSourceOptions;
 
 ---
 
-### DataPipelineProps <a name="DataPipelineProps" id="aws-ddk-dev.DataPipelineProps"></a>
+### DataPipelineProps <a name="DataPipelineProps" id="aws-ddk-core.DataPipelineProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.DataPipelineProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.DataPipelineProps.Initializer"></a>
 
 ```typescript
-import { DataPipelineProps } from 'aws-ddk-dev'
+import { DataPipelineProps } from 'aws-ddk-core'
 
 const dataPipelineProps: DataPipelineProps = { ... }
 ```
@@ -3416,12 +3516,12 @@ const dataPipelineProps: DataPipelineProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.DataPipelineProps.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataPipelineProps.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipelineProps.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataPipelineProps.property.name">name</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.DataPipelineProps.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.DataPipelineProps.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -3431,7 +3531,7 @@ public readonly description: string;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.DataPipelineProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.DataPipelineProps.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3441,12 +3541,12 @@ public readonly name: string;
 
 ---
 
-### DataStageProps <a name="DataStageProps" id="aws-ddk-dev.DataStageProps"></a>
+### DataStageProps <a name="DataStageProps" id="aws-ddk-core.DataStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.DataStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.DataStageProps.Initializer"></a>
 
 ```typescript
-import { DataStageProps } from 'aws-ddk-dev'
+import { DataStageProps } from 'aws-ddk-core'
 
 const dataStageProps: DataStageProps = { ... }
 ```
@@ -3455,12 +3555,12 @@ const dataStageProps: DataStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.DataStageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.DataStageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.DataStageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.DataStageProps.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.DataStageProps.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -3470,7 +3570,7 @@ public readonly description: string;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.DataStageProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.DataStageProps.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3480,12 +3580,12 @@ public readonly name: string;
 
 ---
 
-### EventStageProps <a name="EventStageProps" id="aws-ddk-dev.EventStageProps"></a>
+### EventStageProps <a name="EventStageProps" id="aws-ddk-core.EventStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.EventStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.EventStageProps.Initializer"></a>
 
 ```typescript
-import { EventStageProps } from 'aws-ddk-dev'
+import { EventStageProps } from 'aws-ddk-core'
 
 const eventStageProps: EventStageProps = { ... }
 ```
@@ -3494,12 +3594,12 @@ const eventStageProps: EventStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.EventStageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.EventStageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.EventStageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.EventStageProps.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.EventStageProps.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -3509,7 +3609,7 @@ public readonly description: string;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.EventStageProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.EventStageProps.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3519,12 +3619,12 @@ public readonly name: string;
 
 ---
 
-### GetSynthActionProps <a name="GetSynthActionProps" id="aws-ddk-dev.GetSynthActionProps"></a>
+### GetSynthActionProps <a name="GetSynthActionProps" id="aws-ddk-core.GetSynthActionProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.GetSynthActionProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.GetSynthActionProps.Initializer"></a>
 
 ```typescript
-import { GetSynthActionProps } from 'aws-ddk-dev'
+import { GetSynthActionProps } from 'aws-ddk-core'
 
 const getSynthActionProps: GetSynthActionProps = { ... }
 ```
@@ -3533,19 +3633,19 @@ const getSynthActionProps: GetSynthActionProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.account">account</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.cdkVersion">cdkVersion</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.codeartifactDomain">codeartifactDomain</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.codeartifactDomainOwner">codeartifactDomainOwner</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.codeartifactRepository">codeartifactRepository</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.codePipelineSource">codePipelineSource</a></code> | <code>aws-cdk-lib.pipelines.IFileSetProducer</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.partition">partition</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.region">region</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.GetSynthActionProps.property.rolePolicyStatements">rolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.account">account</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.cdkVersion">cdkVersion</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.codeartifactDomain">codeartifactDomain</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.codeartifactDomainOwner">codeartifactDomainOwner</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.codeartifactRepository">codeartifactRepository</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.codePipelineSource">codePipelineSource</a></code> | <code>aws-cdk-lib.pipelines.IFileSetProducer</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.partition">partition</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.region">region</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.rolePolicyStatements">rolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | *No description.* |
 
 ---
 
-##### `account`<sup>Optional</sup> <a name="account" id="aws-ddk-dev.GetSynthActionProps.property.account"></a>
+##### `account`<sup>Optional</sup> <a name="account" id="aws-ddk-core.GetSynthActionProps.property.account"></a>
 
 ```typescript
 public readonly account: string;
@@ -3555,7 +3655,7 @@ public readonly account: string;
 
 ---
 
-##### `cdkVersion`<sup>Optional</sup> <a name="cdkVersion" id="aws-ddk-dev.GetSynthActionProps.property.cdkVersion"></a>
+##### `cdkVersion`<sup>Optional</sup> <a name="cdkVersion" id="aws-ddk-core.GetSynthActionProps.property.cdkVersion"></a>
 
 ```typescript
 public readonly cdkVersion: string;
@@ -3565,7 +3665,7 @@ public readonly cdkVersion: string;
 
 ---
 
-##### `codeartifactDomain`<sup>Optional</sup> <a name="codeartifactDomain" id="aws-ddk-dev.GetSynthActionProps.property.codeartifactDomain"></a>
+##### `codeartifactDomain`<sup>Optional</sup> <a name="codeartifactDomain" id="aws-ddk-core.GetSynthActionProps.property.codeartifactDomain"></a>
 
 ```typescript
 public readonly codeartifactDomain: string;
@@ -3575,7 +3675,7 @@ public readonly codeartifactDomain: string;
 
 ---
 
-##### `codeartifactDomainOwner`<sup>Optional</sup> <a name="codeartifactDomainOwner" id="aws-ddk-dev.GetSynthActionProps.property.codeartifactDomainOwner"></a>
+##### `codeartifactDomainOwner`<sup>Optional</sup> <a name="codeartifactDomainOwner" id="aws-ddk-core.GetSynthActionProps.property.codeartifactDomainOwner"></a>
 
 ```typescript
 public readonly codeartifactDomainOwner: string;
@@ -3585,7 +3685,7 @@ public readonly codeartifactDomainOwner: string;
 
 ---
 
-##### `codeartifactRepository`<sup>Optional</sup> <a name="codeartifactRepository" id="aws-ddk-dev.GetSynthActionProps.property.codeartifactRepository"></a>
+##### `codeartifactRepository`<sup>Optional</sup> <a name="codeartifactRepository" id="aws-ddk-core.GetSynthActionProps.property.codeartifactRepository"></a>
 
 ```typescript
 public readonly codeartifactRepository: string;
@@ -3595,7 +3695,7 @@ public readonly codeartifactRepository: string;
 
 ---
 
-##### `codePipelineSource`<sup>Optional</sup> <a name="codePipelineSource" id="aws-ddk-dev.GetSynthActionProps.property.codePipelineSource"></a>
+##### `codePipelineSource`<sup>Optional</sup> <a name="codePipelineSource" id="aws-ddk-core.GetSynthActionProps.property.codePipelineSource"></a>
 
 ```typescript
 public readonly codePipelineSource: IFileSetProducer;
@@ -3605,7 +3705,7 @@ public readonly codePipelineSource: IFileSetProducer;
 
 ---
 
-##### `partition`<sup>Optional</sup> <a name="partition" id="aws-ddk-dev.GetSynthActionProps.property.partition"></a>
+##### `partition`<sup>Optional</sup> <a name="partition" id="aws-ddk-core.GetSynthActionProps.property.partition"></a>
 
 ```typescript
 public readonly partition: string;
@@ -3615,7 +3715,7 @@ public readonly partition: string;
 
 ---
 
-##### `region`<sup>Optional</sup> <a name="region" id="aws-ddk-dev.GetSynthActionProps.property.region"></a>
+##### `region`<sup>Optional</sup> <a name="region" id="aws-ddk-core.GetSynthActionProps.property.region"></a>
 
 ```typescript
 public readonly region: string;
@@ -3625,7 +3725,7 @@ public readonly region: string;
 
 ---
 
-##### `rolePolicyStatements`<sup>Optional</sup> <a name="rolePolicyStatements" id="aws-ddk-dev.GetSynthActionProps.property.rolePolicyStatements"></a>
+##### `rolePolicyStatements`<sup>Optional</sup> <a name="rolePolicyStatements" id="aws-ddk-core.GetSynthActionProps.property.rolePolicyStatements"></a>
 
 ```typescript
 public readonly rolePolicyStatements: PolicyStatement[];
@@ -3635,12 +3735,12 @@ public readonly rolePolicyStatements: PolicyStatement[];
 
 ---
 
-### S3EventStageProps <a name="S3EventStageProps" id="aws-ddk-dev.S3EventStageProps"></a>
+### S3EventStageProps <a name="S3EventStageProps" id="aws-ddk-core.S3EventStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.S3EventStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.S3EventStageProps.Initializer"></a>
 
 ```typescript
-import { S3EventStageProps } from 'aws-ddk-dev'
+import { S3EventStageProps } from 'aws-ddk-core'
 
 const s3EventStageProps: S3EventStageProps = { ... }
 ```
@@ -3649,15 +3749,15 @@ const s3EventStageProps: S3EventStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.S3EventStageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStageProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStageProps.property.eventNames">eventNames</a></code> | <code>string[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.S3EventStageProps.property.keyPrefix">keyPrefix</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStageProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStageProps.property.eventNames">eventNames</a></code> | <code>string[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.S3EventStageProps.property.keyPrefix">keyPrefix</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.S3EventStageProps.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.S3EventStageProps.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -3667,7 +3767,7 @@ public readonly description: string;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.S3EventStageProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.S3EventStageProps.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3677,7 +3777,7 @@ public readonly name: string;
 
 ---
 
-##### `bucket`<sup>Required</sup> <a name="bucket" id="aws-ddk-dev.S3EventStageProps.property.bucket"></a>
+##### `bucket`<sup>Required</sup> <a name="bucket" id="aws-ddk-core.S3EventStageProps.property.bucket"></a>
 
 ```typescript
 public readonly bucket: IBucket;
@@ -3687,7 +3787,7 @@ public readonly bucket: IBucket;
 
 ---
 
-##### `eventNames`<sup>Required</sup> <a name="eventNames" id="aws-ddk-dev.S3EventStageProps.property.eventNames"></a>
+##### `eventNames`<sup>Required</sup> <a name="eventNames" id="aws-ddk-core.S3EventStageProps.property.eventNames"></a>
 
 ```typescript
 public readonly eventNames: string[];
@@ -3697,7 +3797,7 @@ public readonly eventNames: string[];
 
 ---
 
-##### `keyPrefix`<sup>Optional</sup> <a name="keyPrefix" id="aws-ddk-dev.S3EventStageProps.property.keyPrefix"></a>
+##### `keyPrefix`<sup>Optional</sup> <a name="keyPrefix" id="aws-ddk-core.S3EventStageProps.property.keyPrefix"></a>
 
 ```typescript
 public readonly keyPrefix: string;
@@ -3707,12 +3807,12 @@ public readonly keyPrefix: string;
 
 ---
 
-### SourceActionProps <a name="SourceActionProps" id="aws-ddk-dev.SourceActionProps"></a>
+### SourceActionProps <a name="SourceActionProps" id="aws-ddk-core.SourceActionProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.SourceActionProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.SourceActionProps.Initializer"></a>
 
 ```typescript
-import { SourceActionProps } from 'aws-ddk-dev'
+import { SourceActionProps } from 'aws-ddk-core'
 
 const sourceActionProps: SourceActionProps = { ... }
 ```
@@ -3721,13 +3821,13 @@ const sourceActionProps: SourceActionProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.SourceActionProps.property.repositoryName">repositoryName</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SourceActionProps.property.branch">branch</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SourceActionProps.property.sourceAction">sourceAction</a></code> | <code>aws-cdk-lib.pipelines.CodePipelineSource</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SourceActionProps.property.repositoryName">repositoryName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SourceActionProps.property.branch">branch</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SourceActionProps.property.sourceAction">sourceAction</a></code> | <code>aws-cdk-lib.pipelines.CodePipelineSource</code> | *No description.* |
 
 ---
 
-##### `repositoryName`<sup>Required</sup> <a name="repositoryName" id="aws-ddk-dev.SourceActionProps.property.repositoryName"></a>
+##### `repositoryName`<sup>Required</sup> <a name="repositoryName" id="aws-ddk-core.SourceActionProps.property.repositoryName"></a>
 
 ```typescript
 public readonly repositoryName: string;
@@ -3737,7 +3837,7 @@ public readonly repositoryName: string;
 
 ---
 
-##### `branch`<sup>Optional</sup> <a name="branch" id="aws-ddk-dev.SourceActionProps.property.branch"></a>
+##### `branch`<sup>Optional</sup> <a name="branch" id="aws-ddk-core.SourceActionProps.property.branch"></a>
 
 ```typescript
 public readonly branch: string;
@@ -3747,7 +3847,7 @@ public readonly branch: string;
 
 ---
 
-##### `sourceAction`<sup>Optional</sup> <a name="sourceAction" id="aws-ddk-dev.SourceActionProps.property.sourceAction"></a>
+##### `sourceAction`<sup>Optional</sup> <a name="sourceAction" id="aws-ddk-core.SourceActionProps.property.sourceAction"></a>
 
 ```typescript
 public readonly sourceAction: CodePipelineSource;
@@ -3757,12 +3857,12 @@ public readonly sourceAction: CodePipelineSource;
 
 ---
 
-### SqsToLambdaStageFunctionProps <a name="SqsToLambdaStageFunctionProps" id="aws-ddk-dev.SqsToLambdaStageFunctionProps"></a>
+### SqsToLambdaStageFunctionProps <a name="SqsToLambdaStageFunctionProps" id="aws-ddk-core.SqsToLambdaStageFunctionProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.SqsToLambdaStageFunctionProps.Initializer"></a>
 
 ```typescript
-import { SqsToLambdaStageFunctionProps } from 'aws-ddk-dev'
+import { SqsToLambdaStageFunctionProps } from 'aws-ddk-core'
 
 const sqsToLambdaStageFunctionProps: SqsToLambdaStageFunctionProps = { ... }
 ```
@@ -3771,19 +3871,19 @@ const sqsToLambdaStageFunctionProps: SqsToLambdaStageFunctionProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.code">code</a></code> | <code>aws-cdk-lib.aws_lambda.Code</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.handler">handler</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.errorsAlarmThreshold">errorsAlarmThreshold</a></code> | <code>number</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.errorsEvaluationPeriods">errorsEvaluationPeriods</a></code> | <code>number</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.layers">layers</a></code> | <code>aws-cdk-lib.aws_lambda.ILayerVersion[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.memorySize">memorySize</a></code> | <code>aws-cdk-lib.Size</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.role">role</a></code> | <code>aws-cdk-lib.aws_iam.Role</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.runtime">runtime</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.code">code</a></code> | <code>aws-cdk-lib.aws_lambda.Code</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.handler">handler</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.errorsAlarmThreshold">errorsAlarmThreshold</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.errorsEvaluationPeriods">errorsEvaluationPeriods</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.layers">layers</a></code> | <code>aws-cdk-lib.aws_lambda.ILayerVersion[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.memorySize">memorySize</a></code> | <code>aws-cdk-lib.Size</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.role">role</a></code> | <code>aws-cdk-lib.aws_iam.Role</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.runtime">runtime</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | *No description.* |
 
 ---
 
-##### `code`<sup>Required</sup> <a name="code" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.code"></a>
+##### `code`<sup>Required</sup> <a name="code" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.code"></a>
 
 ```typescript
 public readonly code: Code;
@@ -3793,7 +3893,7 @@ public readonly code: Code;
 
 ---
 
-##### `handler`<sup>Required</sup> <a name="handler" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.handler"></a>
+##### `handler`<sup>Required</sup> <a name="handler" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.handler"></a>
 
 ```typescript
 public readonly handler: string;
@@ -3803,7 +3903,7 @@ public readonly handler: string;
 
 ---
 
-##### `errorsAlarmThreshold`<sup>Optional</sup> <a name="errorsAlarmThreshold" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.errorsAlarmThreshold"></a>
+##### `errorsAlarmThreshold`<sup>Optional</sup> <a name="errorsAlarmThreshold" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.errorsAlarmThreshold"></a>
 
 ```typescript
 public readonly errorsAlarmThreshold: number;
@@ -3813,7 +3913,7 @@ public readonly errorsAlarmThreshold: number;
 
 ---
 
-##### `errorsEvaluationPeriods`<sup>Optional</sup> <a name="errorsEvaluationPeriods" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.errorsEvaluationPeriods"></a>
+##### `errorsEvaluationPeriods`<sup>Optional</sup> <a name="errorsEvaluationPeriods" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.errorsEvaluationPeriods"></a>
 
 ```typescript
 public readonly errorsEvaluationPeriods: number;
@@ -3823,7 +3923,7 @@ public readonly errorsEvaluationPeriods: number;
 
 ---
 
-##### `layers`<sup>Optional</sup> <a name="layers" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.layers"></a>
+##### `layers`<sup>Optional</sup> <a name="layers" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.layers"></a>
 
 ```typescript
 public readonly layers: ILayerVersion[];
@@ -3833,7 +3933,7 @@ public readonly layers: ILayerVersion[];
 
 ---
 
-##### `memorySize`<sup>Optional</sup> <a name="memorySize" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.memorySize"></a>
+##### `memorySize`<sup>Optional</sup> <a name="memorySize" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.memorySize"></a>
 
 ```typescript
 public readonly memorySize: Size;
@@ -3843,7 +3943,7 @@ public readonly memorySize: Size;
 
 ---
 
-##### `role`<sup>Optional</sup> <a name="role" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.role"></a>
+##### `role`<sup>Optional</sup> <a name="role" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.role"></a>
 
 ```typescript
 public readonly role: Role;
@@ -3853,7 +3953,7 @@ public readonly role: Role;
 
 ---
 
-##### `runtime`<sup>Optional</sup> <a name="runtime" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.runtime"></a>
+##### `runtime`<sup>Optional</sup> <a name="runtime" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.runtime"></a>
 
 ```typescript
 public readonly runtime: Runtime;
@@ -3863,7 +3963,7 @@ public readonly runtime: Runtime;
 
 ---
 
-##### `timeout`<sup>Optional</sup> <a name="timeout" id="aws-ddk-dev.SqsToLambdaStageFunctionProps.property.timeout"></a>
+##### `timeout`<sup>Optional</sup> <a name="timeout" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.timeout"></a>
 
 ```typescript
 public readonly timeout: Duration;
@@ -3873,12 +3973,12 @@ public readonly timeout: Duration;
 
 ---
 
-### SqsToLambdaStageProps <a name="SqsToLambdaStageProps" id="aws-ddk-dev.SqsToLambdaStageProps"></a>
+### SqsToLambdaStageProps <a name="SqsToLambdaStageProps" id="aws-ddk-core.SqsToLambdaStageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.SqsToLambdaStageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.SqsToLambdaStageProps.Initializer"></a>
 
 ```typescript
-import { SqsToLambdaStageProps } from 'aws-ddk-dev'
+import { SqsToLambdaStageProps } from 'aws-ddk-core'
 
 const sqsToLambdaStageProps: SqsToLambdaStageProps = { ... }
 ```
@@ -3887,19 +3987,19 @@ const sqsToLambdaStageProps: SqsToLambdaStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.batchSize">batchSize</a></code> | <code>number</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.dlqEnabled">dlqEnabled</a></code> | <code>boolean</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.lambdaFunction">lambdaFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.lambdaFunctionProps">lambdaFunctionProps</a></code> | <code><a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps">SqsToLambdaStageFunctionProps</a></code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.maxReceiveCount">maxReceiveCount</a></code> | <code>number</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.sqsQueue">sqsQueue</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageProps.property.sqsQueueProps">sqsQueueProps</a></code> | <code><a href="#aws-ddk-dev.SqsToLambdaStageQueueProps">SqsToLambdaStageQueueProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.batchSize">batchSize</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.dlqEnabled">dlqEnabled</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.lambdaFunction">lambdaFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.lambdaFunctionProps">lambdaFunctionProps</a></code> | <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps">SqsToLambdaStageFunctionProps</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.maxReceiveCount">maxReceiveCount</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.sqsQueue">sqsQueue</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageProps.property.sqsQueueProps">sqsQueueProps</a></code> | <code><a href="#aws-ddk-core.SqsToLambdaStageQueueProps">SqsToLambdaStageQueueProps</a></code> | *No description.* |
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.SqsToLambdaStageProps.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.SqsToLambdaStageProps.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -3909,7 +4009,7 @@ public readonly description: string;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.SqsToLambdaStageProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.SqsToLambdaStageProps.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3919,7 +4019,7 @@ public readonly name: string;
 
 ---
 
-##### `batchSize`<sup>Optional</sup> <a name="batchSize" id="aws-ddk-dev.SqsToLambdaStageProps.property.batchSize"></a>
+##### `batchSize`<sup>Optional</sup> <a name="batchSize" id="aws-ddk-core.SqsToLambdaStageProps.property.batchSize"></a>
 
 ```typescript
 public readonly batchSize: number;
@@ -3929,7 +4029,7 @@ public readonly batchSize: number;
 
 ---
 
-##### `dlqEnabled`<sup>Optional</sup> <a name="dlqEnabled" id="aws-ddk-dev.SqsToLambdaStageProps.property.dlqEnabled"></a>
+##### `dlqEnabled`<sup>Optional</sup> <a name="dlqEnabled" id="aws-ddk-core.SqsToLambdaStageProps.property.dlqEnabled"></a>
 
 ```typescript
 public readonly dlqEnabled: boolean;
@@ -3939,7 +4039,7 @@ public readonly dlqEnabled: boolean;
 
 ---
 
-##### `lambdaFunction`<sup>Optional</sup> <a name="lambdaFunction" id="aws-ddk-dev.SqsToLambdaStageProps.property.lambdaFunction"></a>
+##### `lambdaFunction`<sup>Optional</sup> <a name="lambdaFunction" id="aws-ddk-core.SqsToLambdaStageProps.property.lambdaFunction"></a>
 
 ```typescript
 public readonly lambdaFunction: IFunction;
@@ -3949,17 +4049,17 @@ public readonly lambdaFunction: IFunction;
 
 ---
 
-##### `lambdaFunctionProps`<sup>Optional</sup> <a name="lambdaFunctionProps" id="aws-ddk-dev.SqsToLambdaStageProps.property.lambdaFunctionProps"></a>
+##### `lambdaFunctionProps`<sup>Optional</sup> <a name="lambdaFunctionProps" id="aws-ddk-core.SqsToLambdaStageProps.property.lambdaFunctionProps"></a>
 
 ```typescript
 public readonly lambdaFunctionProps: SqsToLambdaStageFunctionProps;
 ```
 
-- *Type:* <a href="#aws-ddk-dev.SqsToLambdaStageFunctionProps">SqsToLambdaStageFunctionProps</a>
+- *Type:* <a href="#aws-ddk-core.SqsToLambdaStageFunctionProps">SqsToLambdaStageFunctionProps</a>
 
 ---
 
-##### `maxReceiveCount`<sup>Optional</sup> <a name="maxReceiveCount" id="aws-ddk-dev.SqsToLambdaStageProps.property.maxReceiveCount"></a>
+##### `maxReceiveCount`<sup>Optional</sup> <a name="maxReceiveCount" id="aws-ddk-core.SqsToLambdaStageProps.property.maxReceiveCount"></a>
 
 ```typescript
 public readonly maxReceiveCount: number;
@@ -3969,7 +4069,7 @@ public readonly maxReceiveCount: number;
 
 ---
 
-##### `sqsQueue`<sup>Optional</sup> <a name="sqsQueue" id="aws-ddk-dev.SqsToLambdaStageProps.property.sqsQueue"></a>
+##### `sqsQueue`<sup>Optional</sup> <a name="sqsQueue" id="aws-ddk-core.SqsToLambdaStageProps.property.sqsQueue"></a>
 
 ```typescript
 public readonly sqsQueue: IQueue;
@@ -3979,22 +4079,22 @@ public readonly sqsQueue: IQueue;
 
 ---
 
-##### `sqsQueueProps`<sup>Optional</sup> <a name="sqsQueueProps" id="aws-ddk-dev.SqsToLambdaStageProps.property.sqsQueueProps"></a>
+##### `sqsQueueProps`<sup>Optional</sup> <a name="sqsQueueProps" id="aws-ddk-core.SqsToLambdaStageProps.property.sqsQueueProps"></a>
 
 ```typescript
 public readonly sqsQueueProps: SqsToLambdaStageQueueProps;
 ```
 
-- *Type:* <a href="#aws-ddk-dev.SqsToLambdaStageQueueProps">SqsToLambdaStageQueueProps</a>
+- *Type:* <a href="#aws-ddk-core.SqsToLambdaStageQueueProps">SqsToLambdaStageQueueProps</a>
 
 ---
 
-### SqsToLambdaStageQueueProps <a name="SqsToLambdaStageQueueProps" id="aws-ddk-dev.SqsToLambdaStageQueueProps"></a>
+### SqsToLambdaStageQueueProps <a name="SqsToLambdaStageQueueProps" id="aws-ddk-core.SqsToLambdaStageQueueProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.SqsToLambdaStageQueueProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.SqsToLambdaStageQueueProps.Initializer"></a>
 
 ```typescript
-import { SqsToLambdaStageQueueProps } from 'aws-ddk-dev'
+import { SqsToLambdaStageQueueProps } from 'aws-ddk-core'
 
 const sqsToLambdaStageQueueProps: SqsToLambdaStageQueueProps = { ... }
 ```
@@ -4003,11 +4103,11 @@ const sqsToLambdaStageQueueProps: SqsToLambdaStageQueueProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.SqsToLambdaStageQueueProps.property.visibilityTimeout">visibilityTimeout</a></code> | <code>aws-cdk-lib.Duration</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageQueueProps.property.visibilityTimeout">visibilityTimeout</a></code> | <code>aws-cdk-lib.Duration</code> | *No description.* |
 
 ---
 
-##### `visibilityTimeout`<sup>Optional</sup> <a name="visibilityTimeout" id="aws-ddk-dev.SqsToLambdaStageQueueProps.property.visibilityTimeout"></a>
+##### `visibilityTimeout`<sup>Optional</sup> <a name="visibilityTimeout" id="aws-ddk-core.SqsToLambdaStageQueueProps.property.visibilityTimeout"></a>
 
 ```typescript
 public readonly visibilityTimeout: Duration;
@@ -4017,12 +4117,12 @@ public readonly visibilityTimeout: Duration;
 
 ---
 
-### StageProps <a name="StageProps" id="aws-ddk-dev.StageProps"></a>
+### StageProps <a name="StageProps" id="aws-ddk-core.StageProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.StageProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.StageProps.Initializer"></a>
 
 ```typescript
-import { StageProps } from 'aws-ddk-dev'
+import { StageProps } from 'aws-ddk-core'
 
 const stageProps: StageProps = { ... }
 ```
@@ -4031,12 +4131,12 @@ const stageProps: StageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.StageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.StageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.StageProps.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.StageProps.property.name">name</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-dev.StageProps.property.description"></a>
+##### `description`<sup>Optional</sup> <a name="description" id="aws-ddk-core.StageProps.property.description"></a>
 
 ```typescript
 public readonly description: string;
@@ -4046,7 +4146,7 @@ public readonly description: string;
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-dev.StageProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="aws-ddk-core.StageProps.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4056,12 +4156,12 @@ public readonly name: string;
 
 ---
 
-### SynthActionProps <a name="SynthActionProps" id="aws-ddk-dev.SynthActionProps"></a>
+### SynthActionProps <a name="SynthActionProps" id="aws-ddk-core.SynthActionProps"></a>
 
-#### Initializer <a name="Initializer" id="aws-ddk-dev.SynthActionProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="aws-ddk-core.SynthActionProps.Initializer"></a>
 
 ```typescript
-import { SynthActionProps } from 'aws-ddk-dev'
+import { SynthActionProps } from 'aws-ddk-core'
 
 const synthActionProps: SynthActionProps = { ... }
 ```
@@ -4070,16 +4170,16 @@ const synthActionProps: SynthActionProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-ddk-dev.SynthActionProps.property.cdkVersion">cdkVersion</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SynthActionProps.property.codeartifactDomain">codeartifactDomain</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SynthActionProps.property.codeartifactDomainOwner">codeartifactDomainOwner</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SynthActionProps.property.codeartifactRepository">codeartifactRepository</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SynthActionProps.property.rolePolicyStatements">rolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | *No description.* |
-| <code><a href="#aws-ddk-dev.SynthActionProps.property.synthAction">synthAction</a></code> | <code>aws-cdk-lib.pipelines.CodeBuildStep</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SynthActionProps.property.cdkVersion">cdkVersion</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SynthActionProps.property.codeartifactDomain">codeartifactDomain</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SynthActionProps.property.codeartifactDomainOwner">codeartifactDomainOwner</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SynthActionProps.property.codeartifactRepository">codeartifactRepository</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SynthActionProps.property.rolePolicyStatements">rolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | *No description.* |
+| <code><a href="#aws-ddk-core.SynthActionProps.property.synthAction">synthAction</a></code> | <code>aws-cdk-lib.pipelines.CodeBuildStep</code> | *No description.* |
 
 ---
 
-##### `cdkVersion`<sup>Optional</sup> <a name="cdkVersion" id="aws-ddk-dev.SynthActionProps.property.cdkVersion"></a>
+##### `cdkVersion`<sup>Optional</sup> <a name="cdkVersion" id="aws-ddk-core.SynthActionProps.property.cdkVersion"></a>
 
 ```typescript
 public readonly cdkVersion: string;
@@ -4089,7 +4189,7 @@ public readonly cdkVersion: string;
 
 ---
 
-##### `codeartifactDomain`<sup>Optional</sup> <a name="codeartifactDomain" id="aws-ddk-dev.SynthActionProps.property.codeartifactDomain"></a>
+##### `codeartifactDomain`<sup>Optional</sup> <a name="codeartifactDomain" id="aws-ddk-core.SynthActionProps.property.codeartifactDomain"></a>
 
 ```typescript
 public readonly codeartifactDomain: string;
@@ -4099,7 +4199,7 @@ public readonly codeartifactDomain: string;
 
 ---
 
-##### `codeartifactDomainOwner`<sup>Optional</sup> <a name="codeartifactDomainOwner" id="aws-ddk-dev.SynthActionProps.property.codeartifactDomainOwner"></a>
+##### `codeartifactDomainOwner`<sup>Optional</sup> <a name="codeartifactDomainOwner" id="aws-ddk-core.SynthActionProps.property.codeartifactDomainOwner"></a>
 
 ```typescript
 public readonly codeartifactDomainOwner: string;
@@ -4109,7 +4209,7 @@ public readonly codeartifactDomainOwner: string;
 
 ---
 
-##### `codeartifactRepository`<sup>Optional</sup> <a name="codeartifactRepository" id="aws-ddk-dev.SynthActionProps.property.codeartifactRepository"></a>
+##### `codeartifactRepository`<sup>Optional</sup> <a name="codeartifactRepository" id="aws-ddk-core.SynthActionProps.property.codeartifactRepository"></a>
 
 ```typescript
 public readonly codeartifactRepository: string;
@@ -4119,7 +4219,7 @@ public readonly codeartifactRepository: string;
 
 ---
 
-##### `rolePolicyStatements`<sup>Optional</sup> <a name="rolePolicyStatements" id="aws-ddk-dev.SynthActionProps.property.rolePolicyStatements"></a>
+##### `rolePolicyStatements`<sup>Optional</sup> <a name="rolePolicyStatements" id="aws-ddk-core.SynthActionProps.property.rolePolicyStatements"></a>
 
 ```typescript
 public readonly rolePolicyStatements: PolicyStatement[];
@@ -4129,7 +4229,7 @@ public readonly rolePolicyStatements: PolicyStatement[];
 
 ---
 
-##### `synthAction`<sup>Optional</sup> <a name="synthAction" id="aws-ddk-dev.SynthActionProps.property.synthAction"></a>
+##### `synthAction`<sup>Optional</sup> <a name="synthAction" id="aws-ddk-core.SynthActionProps.property.synthAction"></a>
 
 ```typescript
 public readonly synthAction: CodeBuildStep;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.34.0",
+    "aws-cdk-lib": "2.38.1",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
@@ -57,7 +57,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.34.0",
+    "aws-cdk-lib": "^2.38.1",
     "constructs": "^10.0.5"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-ddk-dev",
+  "name": "aws-ddk-core",
   "description": "AWS DataOps Development Kit",
   "repository": {
     "type": "git",
@@ -17,6 +17,7 @@
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:js": "npx projen package:js",
+    "package:python": "npx projen package:python",
     "post-compile": "npx projen post-compile",
     "post-upgrade": "npx projen post-upgrade",
     "pre-compile": "npx projen pre-compile",
@@ -37,7 +38,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.1.0",
+    "aws-cdk-lib": "2.34.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
@@ -56,7 +57,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.34.0",
     "constructs": "^10.0.5"
   },
   "keywords": [
@@ -109,7 +110,12 @@
   "stability": "stable",
   "jsii": {
     "outdir": "dist",
-    "targets": {},
+    "targets": {
+      "python": {
+        "distName": "aws-ddk-core",
+        "module": "aws_ddk_core"
+      }
+    },
     "tsc": {
       "outDir": "lib",
       "rootDir": "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1194,10 +1194,10 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk-lib@2.34.0:
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.34.0.tgz#89b8c03d40d0814800e57a8431c183453c5f0cdc"
-  integrity sha512-fA14Zs+U2sohdCV+FhCR5K8wEimMdFS4m/e0h/I6jn2QaUeUG3DGAjxeZT1oPyn8pqL6/x5mYJCg19sIEn708w==
+aws-cdk-lib@2.38.1:
+  version "2.38.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.38.1.tgz#e96ee1362c86260786b3d808f593ca5edd813b29"
+  integrity sha512-vEgJBUzL1yqlSMYGjipl+eRwy900x3RmbVzTcxKdCZvhtBMQ1hqJAMgVswvoyA5EnvfELLlz9ufm+qdKGs9DxQ==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1194,19 +1194,19 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk-lib@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.1.0.tgz#2497484cfd4e2eeaba99b070bbfa54486d52ae34"
-  integrity sha512-W607G3aSrWpawpcqzIuUYKlU+grfvkbszyqikyVYqJgMHFCCQXq0S1ynPMzfQ49CwjlwZsu4LIsPM+dNR+Yj6g==
+aws-cdk-lib@2.34.0:
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.34.0.tgz#89b8c03d40d0814800e57a8431c183453c5f0cdc"
+  integrity sha512-fA14Zs+U2sohdCV+FhCR5K8wEimMdFS4m/e0h/I6jn2QaUeUG3DGAjxeZT1oPyn8pqL6/x5mYJCg19sIEn708w==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
-    ignore "^5.1.9"
-    jsonschema "^1.4.0"
-    minimatch "^3.0.4"
+    ignore "^5.2.0"
+    jsonschema "^1.4.1"
+    minimatch "^3.1.2"
     punycode "^2.1.1"
-    semver "^7.3.5"
+    semver "^7.3.7"
     yaml "1.10.2"
 
 babel-jest@^27.5.1:
@@ -2703,7 +2703,7 @@ ignore-walk@^5.0.1:
   dependencies:
     minimatch "^5.0.1"
 
-ignore@^5.1.9, ignore@^5.2.0:
+ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -3671,7 +3671,7 @@ jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonschema@^1.4.0:
+jsonschema@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
   integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==


### PR DESCRIPTION
### Detail
- Upgraded CDK version to `v2.34.0`
- Added configuration for JSII to generate Python objects
- Changed module name to `aws-cdk-core`, to reflect the name of the Python package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
