### PR TITLE
fix: CICD: Presynth install commands -> optional

### DIFF
--- a/API.md
+++ b/API.md
@@ -3718,6 +3718,7 @@ const getSynthActionProps: GetSynthActionProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#aws-ddk-core.GetSynthActionProps.property.account">account</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetSynthActionProps.property.additionalInstallCommands">additionalInstallCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#aws-ddk-core.GetSynthActionProps.property.cdkVersion">cdkVersion</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.GetSynthActionProps.property.codeartifactDomain">codeartifactDomain</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.GetSynthActionProps.property.codeartifactDomainOwner">codeartifactDomainOwner</a></code> | <code>string</code> | *No description.* |
@@ -3736,6 +3737,16 @@ public readonly account: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `additionalInstallCommands`<sup>Optional</sup> <a name="additionalInstallCommands" id="aws-ddk-core.GetSynthActionProps.property.additionalInstallCommands"></a>
+
+```typescript
+public readonly additionalInstallCommands: string[];
+```
+
+- *Type:* string[]
 
 ---
 
@@ -4453,12 +4464,23 @@ const synthActionProps: SynthActionProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#aws-ddk-core.SynthActionProps.property.additionalInstallCommands">additionalInstallCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#aws-ddk-core.SynthActionProps.property.cdkVersion">cdkVersion</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.SynthActionProps.property.codeartifactDomain">codeartifactDomain</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.SynthActionProps.property.codeartifactDomainOwner">codeartifactDomainOwner</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.SynthActionProps.property.codeartifactRepository">codeartifactRepository</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.SynthActionProps.property.rolePolicyStatements">rolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | *No description.* |
 | <code><a href="#aws-ddk-core.SynthActionProps.property.synthAction">synthAction</a></code> | <code>aws-cdk-lib.pipelines.CodeBuildStep</code> | *No description.* |
+
+---
+
+##### `additionalInstallCommands`<sup>Optional</sup> <a name="additionalInstallCommands" id="aws-ddk-core.SynthActionProps.property.additionalInstallCommands"></a>
+
+```typescript
+public readonly additionalInstallCommands: string[];
+```
+
+- *Type:* string[]
 
 ---
 

--- a/src/cicd/actions.ts
+++ b/src/cicd/actions.ts
@@ -20,6 +20,7 @@ export interface GetSynthActionProps {
   readonly codeartifactRepository?: string;
   readonly codeartifactDomain?: string;
   readonly codeartifactDomainOwner?: string;
+  readonly additionalInstallCommands?: string[];
 }
 
 export interface CodeCommitSourceActionProps {
@@ -47,7 +48,9 @@ export function getSynthAction(props: GetSynthActionProps): CodeBuildStep {
 
   //   install_commands.psuh(`aws codeartifact login --tool pip --repository ${codeArtifactRepository} --domain ${codeArtifactDomain} --domain-owner ${codeArtifactDomainOwner}`);
   // }
-  installCommands.push('npm install'); // will need to be replaced with `npm install aws-ddk-core@${version}` when available
+  if (props.additionalInstallCommands != undefined && props.additionalInstallCommands.length > 0) {
+    installCommands.concat(props.additionalInstallCommands); // will need to be replaced with `npm install aws-ddk-core@${version}` when available
+  }
   return new CodeBuildStep('Synth', {
     input: props.codePipelineSource,
     installCommands: installCommands,

--- a/src/cicd/pipelines.ts
+++ b/src/cicd/pipelines.ts
@@ -27,6 +27,7 @@ export interface SynthActionProps {
   readonly codeartifactDomainOwner?: string;
   readonly rolePolicyStatements?: PolicyStatement[];
   readonly synthAction?: CodeBuildStep;
+  readonly additionalInstallCommands?: string[];
 }
 
 export interface AddApplicationStageProps {
@@ -118,6 +119,7 @@ export class CICDPipelineStack extends Stack {
         codeartifactRepository: props.codeartifactRepository, // || this._artifactory_config.get('repository'),
         codeartifactDomain: props.codeartifactDomain, // || this._artifactory_config.get('domain'),
         codeartifactDomainOwner: props.codeartifactDomainOwner, //|| this._artifactory_config.get('domain_owner')
+        additionalInstallCommands: props.additionalInstallCommands,
       });
     return this;
   }


### PR DESCRIPTION
### Feature or Bugfix
- Making install commands in the synth action stage optional as these may change in different languages and not be necessary all of the time.

### Detail
- Python implementation requires `[]` in most cases while Typescript requires `[npm install]`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
