### PR TITLE
Update glue_transform.py

### DIFF
--- a/core/aws_ddk_core/stages/glue_transform.py
+++ b/core/aws_ddk_core/stages/glue_transform.py
@@ -108,6 +108,7 @@ class GlueTransformStage(StateMachineStage):
             self._crawler = CfnCrawler(
                 self,
                 f"{id}-crawler",
+                name=f"{id}_crawler",
                 database_name=database_name,
                 targets=targets,
                 role=crawler_role.role_arn,  # type: ignore


### PR DESCRIPTION
Fix issue when crawler name is not specified by assigning name attribute

### Feature or Bugfix
- Bugfix


### Detail
- When Glue crawler name is not specified, the StepFunction will attempt to use the crawler_name, but it is never set so the StepFunction is using a null crawler_name, causing a CloudFormation failure. The fix assigns a crawler_name attribute when crawler name is not specified, fixing the StepFunction related issue

### Relates
- <URL or Ticket>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
