### PR TITLE
`S3 Event Stage`: Support Multiple Buckets

### DIFF
--- a/core/aws_ddk_core/stages/s3_event.py
+++ b/core/aws_ddk_core/stages/s3_event.py
@@ -15,7 +15,6 @@
 from typing import Any, Dict, List, Optional, Union
 
 from aws_cdk.aws_events import EventPattern
-from aws_cdk.aws_s3 import Bucket
 from aws_ddk_core.pipelines import EventStage
 from constructs import Construct
 
@@ -31,7 +30,7 @@ class S3EventStage(EventStage):
         id: str,
         environment_id: str,
         event_names: List[str],
-        bucket_name: str,
+        bucket_name: Union[str, List[str]],
         key_prefix: Optional[Union[str, List[str]]] = None,
         **kwargs: Any,
     ) -> None:
@@ -52,17 +51,16 @@ class S3EventStage(EventStage):
         event_names : List[str]
             The list of events to capture, for example: ["Object Created"].
             https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html
-        bucket_name : str
-            The name of the S3 bucket. Amazon EventBridge notifications must be enabled
+        bucket_name : Union[str, List[str]]
+            The name(s) of the S3 bucket(s). Amazon EventBridge notifications must be enabled
             on the bucket in order to use this construct.
         key_prefix : Optional[Union[str, List[str]]]
             The S3 prefix or list of prefixes. Capture root level prefix ("/") by default
         """
         super().__init__(scope, id, **kwargs)
-        self._bucket = Bucket.from_bucket_name(self, id=f"{id}-bucket", bucket_name=bucket_name)
         detail: Dict[str, Any] = {
             "bucket": {
-                "name": [bucket_name],
+                "name": [bucket_name] if isinstance(bucket_name, str) else bucket_name,
             },
         }
 

--- a/core/tests/unit/test_s3_event_stage.py
+++ b/core/tests/unit/test_s3_event_stage.py
@@ -57,3 +57,30 @@ def test_s3_event_stage_multiple_prefixes(test_stack: BaseStack) -> None:
     )
 
     assert [{"prefix": key} for key in prefixes] == s3_event_stage.event_pattern.detail["object"]["key"]
+
+
+def test_s3_event_stage_multiple_buckets(test_stack: BaseStack) -> None:
+    prefixes = ["data-0", "data-1", "data-2"]
+
+    bucket_1 = S3Factory.bucket(
+        scope=test_stack,
+        id="dummy-bucket-1",
+        environment_id="dev",
+    )
+    bucket_2 = S3Factory.bucket(
+        scope=test_stack,
+        id="dummy-bucket-2",
+        environment_id="dev",
+    )
+
+    s3_event_stage = S3EventStage(
+        scope=test_stack,
+        id="dummy-s3-event",
+        environment_id="dev",
+        event_names=["Object Created"],
+        bucket_name=[bucket_1.bucket_name, bucket_2.bucket_name],
+        key_prefix=prefixes,
+    )
+
+    assert [{"prefix": key} for key in prefixes] == s3_event_stage.event_pattern.detail["object"]["key"]
+    assert [bucket_1.bucket_name, bucket_2.bucket_name] == s3_event_stage.event_pattern.detail["bucket"]["name"]


### PR DESCRIPTION
### Enhancement
- `S3 Event Stage`: Support Multiple Buckets

### Detail
- Allow a list of buckets passed to `bucket_name`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
