### PR TITLE
Feature: Add `add_wave` support to `CICDPipelineStack` construct

### DIFF
--- a/core/aws_ddk_core/cicd/pipeline.py
+++ b/core/aws_ddk_core/cicd/pipeline.py
@@ -287,6 +287,39 @@ class CICDPipelineStack(BaseStack):
         )
         return self
 
+    def add_wave(
+        self,
+        stage_id: str,
+        stages: List[Stage],
+        manual_approvals: Optional[bool] = False,
+    ) -> "CICDPipelineStack":
+        """
+        Add multiple application stages in parallel to the CICD pipeline.
+
+        Parameters
+        ----------
+        stage_id: str
+            Identifier of the wave
+        stages: List[Stage]
+            Application stage instance
+        manual_approvals: Optional[bool]
+            Configure manual approvals. False by default
+
+        Returns
+        -------
+        pipeline : CICDPipelineStack
+            CICDPipelineStack
+        """
+        manual_approvals = manual_approvals or self._config.get_env_config(stage_id).get("manual_approvals")
+
+        wave = self._pipeline.add_wave(
+            stage_id,
+            pre=[ManualApprovalStep(f"PromoteTo{stage_id.title()}")] if manual_approvals else None,
+        )
+        for stage in stages:
+            wave.add_stage(stage)
+        return self
+
     def add_security_lint_stage(
         self,
         stage_name: Optional[str] = None,

--- a/core/aws_ddk_core/pipelines/pipeline.py
+++ b/core/aws_ddk_core/pipelines/pipeline.py
@@ -34,7 +34,11 @@ class DataPipeline(Construct):
     """
 
     def __init__(
-        self, scope: Construct, id: str, name: Optional[str] = None, description: Optional[str] = None
+        self,
+        scope: Construct,
+        id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
     ) -> None:
         """
         Create a data pipeline.
@@ -60,7 +64,10 @@ class DataPipeline(Construct):
         self._notifications_topic: Optional[ITopic] = None
 
     def add_stage(
-        self, stage: DataStage, skip_rule: bool = False, override_rule: Optional[Rule] = None
+        self,
+        stage: DataStage,
+        skip_rule: bool = False,
+        override_rule: Optional[Rule] = None,
     ) -> "DataPipeline":
         """
         Add a stage to the data pipeline.


### PR DESCRIPTION
### Feature
- Add `add_wave` support to `CICDPipelineStack` construct

### Detail
- `add_wave()` allows the user to create parallel CDK deployment stages in parallel which will help support cases with several independent cdk stacks managed in one CI/CD pipeline.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
