### PR TITLE
Bug: Windows `ddk deploy` Issue

### DIFF
--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -33,8 +33,9 @@ def cdk_deploy(
     echo(f"Deploying DDK stacks: {stacks} to AWS account {get_account_id()} and region {get_region()}...")
 
     # generate command
+    file = "cdk.CMD" if os.name == "nt" else "cdk"
     cmd = (
-        f"cdk deploy {' '.join(stacks) if stacks else '--all'} "
+        f"{file} deploy {' '.join(stacks) if stacks else '--all'} "
         f"{'--require-approval ' + require_approval + ' ' if require_approval else ''}"
         f"{'-f ' if force else ''}"
         f"--output {output_dir if output_dir else '.ddk.out'}"

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -14,7 +14,7 @@
 
 import logging
 import os
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 from aws_ddk.sh import run
 from aws_ddk.utils import get_account_id, get_region
@@ -36,7 +36,7 @@ def cdk_deploy(
     # generate command
     if os.name == "nt":
         file = "cdk.CMD"
-        run_args = {"text": True}
+        run_args: Any = {"text": True}
     else:
         file = "cdk"
         run_args = {}

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
+import os
 from typing import Iterable, Optional
 
 from aws_ddk.sh import run

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import logging
 from typing import Iterable, Optional
 

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -34,7 +34,13 @@ def cdk_deploy(
     echo(f"Deploying DDK stacks: {stacks} to AWS account {get_account_id()} and region {get_region()}...")
 
     # generate command
-    file = "cdk.CMD" if os.name == "nt" else "cdk"
+    if os.name == "nt":
+        file = "cdk.CMD"
+        run_args = {"text": True}
+    else:
+        file = "cdk"
+        run_args = {}
+
     cmd = (
         f"{file} deploy {' '.join(stacks) if stacks else '--all'} "
         f"{'--require-approval ' + require_approval + ' ' if require_approval else ''}"
@@ -45,7 +51,7 @@ def cdk_deploy(
         cmd += f" --profile {profile}"
 
     try:
-        run(cmd)
+        run(cmd, **run_args)
     except Exception as e:
         raise SystemExit(f"ERROR - Failed to run `{cmd}`. Exception: {e}.")
     echo("Done.")

--- a/cli/aws_ddk/commands/deploy.py
+++ b/cli/aws_ddk/commands/deploy.py
@@ -44,6 +44,6 @@ def cdk_deploy(
 
     try:
         run(cmd)
-    except Exception:
-        raise SystemExit(f"ERROR - Failed to run `{cmd}`. See output above.")
+    except Exception as e:
+        raise SystemExit(f"ERROR - Failed to run `{cmd}`. Exception: {e}.")
     echo("Done.")

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -29,7 +29,7 @@ def _clean_up_stdout_line(line: bytes) -> str:
 
 
 def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
-    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
     if p.stdout is None:
         return []
     while p.poll() is None:

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -24,11 +24,9 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _clean_up_stdout_line(line: bytes) -> str:
-    print(f"DEBUG: line: {line}")
     try:
         line_str = line.decode("utf-8")
     except:
-        print("line has alredy been decoded")
         line_str = line
     return line_str[:-1] if line_str.endswith("\n") else line_str
 

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -36,7 +36,7 @@ def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
     if p.stdout is None:
         return []
     while p.poll() is None:
-        print(f"line type: {p.stdout.readline()}")
+        print(f"line type: {type(p.stdout.readline())}")
         yield _clean_up_stdout_line(line=p.stdout.readline())
     if p.returncode != 0:
         raise FailedShellCommand(f"Exit code: {p.returncode}")

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -25,7 +25,11 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 def _clean_up_stdout_line(line: bytes) -> str:
     print(f"DEBUG: line: {line}")
-    line_str = line.decode("utf-8")
+    try:
+        line_str = line.decode("utf-8")
+    except:
+        print("line has alredy been decoded")
+        line_str = line
     return line_str[:-1] if line_str.endswith("\n") else line_str
 
 

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -15,7 +15,7 @@
 import logging
 import shlex
 import subprocess
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 from aws_ddk.exceptions import FailedShellCommand
 from click import echo
@@ -28,8 +28,8 @@ def _clean_up_stdout_line(line: bytes) -> str:
     return line_str[:-1] if line_str.endswith("\n") else line_str
 
 
-def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
-    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+def _run_iterating(cmd: str, cwd: Optional[str] = None, **kwargs: Any) -> Iterable[str]:
+    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs)
     if p.stdout is None:
         return []
     while p.poll() is None:
@@ -39,8 +39,8 @@ def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
         raise FailedShellCommand(f"Exit code: {p.returncode}")
 
 
-def run(cmd: str, cwd: Optional[str] = None, hide_cmd: bool = False) -> None:
+def run(cmd: str, cwd: Optional[str] = None, hide_cmd: bool = False, **kwargs: Any) -> None:
     if hide_cmd is False:
         _logger.debug(f"+ {cmd}")
-    for line in _run_iterating(cmd=cmd, cwd=cwd):
+    for line in _run_iterating(cmd=cmd, cwd=cwd, **kwargs):
         echo(line)

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -29,7 +29,7 @@ def _clean_up_stdout_line(line: bytes) -> str:
 
 
 def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
-    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     if p.stdout is None:
         return []
     while p.poll() is None:

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -29,7 +29,7 @@ def _clean_up_stdout_line(line: bytes) -> str:
 
 
 def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
-    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, encoding="utf-8")
     if p.stdout is None:
         return []
     while p.poll() is None:

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -24,7 +24,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _clean_up_stdout_line(line: bytes) -> str:
-    print(f"DEBUG: line_str{line_str}")
+    print(f"DEBUG: line: {line}")
     line_str = line.decode("utf-8")
     return line_str[:-1] if line_str.endswith("\n") else line_str
 

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -29,7 +29,7 @@ def _clean_up_stdout_line(line: bytes) -> str:
 
 
 def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
-    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
     if p.stdout is None:
         return []
     while p.poll() is None:

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -24,6 +24,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _clean_up_stdout_line(line: bytes) -> str:
+    print(f"DEBUG: line_str{line_str}")
     line_str = line.decode("utf-8")
     return line_str[:-1] if line_str.endswith("\n") else line_str
 

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -24,9 +24,6 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _clean_up_stdout_line(line: bytes) -> str:
-    print(f"text: {line}")
-    if line == "\n":    
-        print("newline")
     try:
         line_str = line.decode("utf-8")
     except Exception:
@@ -39,6 +36,7 @@ def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
     if p.stdout is None:
         return []
     while p.poll() is None:
+        print(f"line type: {p.stdout.readline()}")
         yield _clean_up_stdout_line(line=p.stdout.readline())
     if p.returncode != 0:
         raise FailedShellCommand(f"Exit code: {p.returncode}")

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -24,10 +24,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _clean_up_stdout_line(line: bytes) -> str:
-    try:
-        line_str = line.decode("utf-8")
-    except Exception:
-        line_str = line
+    line_str = line.decode("utf-8")
     return line_str[:-1] if line_str.endswith("\n") else line_str
 
 
@@ -36,8 +33,8 @@ def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
     if p.stdout is None:
         return []
     while p.poll() is None:
-        print(f"line type: {type(p.stdout.readline())}")
-        yield _clean_up_stdout_line(line=p.stdout.readline())
+        line = p.stdout.readline()
+        yield _clean_up_stdout_line(line=p.stdout.readline()) if type(bytes) else line
     if p.returncode != 0:
         raise FailedShellCommand(f"Exit code: {p.returncode}")
 

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -29,7 +29,7 @@ def _clean_up_stdout_line(line: bytes) -> str:
 
 
 def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
-    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, encoding="utf-8")
+    p = subprocess.Popen(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
     if p.stdout is None:
         return []
     while p.poll() is None:

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -24,9 +24,12 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _clean_up_stdout_line(line: bytes) -> str:
+    print(f"text: {line}")
+    if line == "\n":    
+        print("newline")
     try:
         line_str = line.decode("utf-8")
-    except:
+    except Exception:
         line_str = line
     return line_str[:-1] if line_str.endswith("\n") else line_str
 

--- a/cli/aws_ddk/sh.py
+++ b/cli/aws_ddk/sh.py
@@ -34,7 +34,7 @@ def _run_iterating(cmd: str, cwd: Optional[str] = None) -> Iterable[str]:
         return []
     while p.poll() is None:
         line = p.stdout.readline()
-        yield _clean_up_stdout_line(line=p.stdout.readline()) if type(bytes) else line
+        yield _clean_up_stdout_line(line=p.stdout.readline()) if isinstance(line, bytes) else line
     if p.returncode != 0:
         raise FailedShellCommand(f"Exit code: {p.returncode}")
 


### PR DESCRIPTION
### Relates
- #178 

### Details
- Windows as opposed to POSIX is not able to find `cdk` within a `subprocess.Popen`, but _**is**_ able to find `cdk.CMD`. 
- Windows does not appear to work with `text=False` in [`subprocess.Popen`](https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module) for this use case and errors with [this error](https://github.com/awslabs/aws-ddk/issues/178#issuecomment-1294035914). By setting stdout to text not bytes we seem to be able to avoid this issue in the case of a Windows OS. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
