### PR TITLE
Enhancement: `SqsToLambdaStage` Adding support for fifo event target 

### DIFF
--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -174,7 +174,7 @@ class SqsToLambdaStage(DataStage):
             dead_letter_queue=self._dlq,
         )
 
-        if hasattr(sqs_queue, "fifo") and sqs_queue.fifo and not message_group_id: # type: ignore
+        if hasattr(sqs_queue, "fifo") and sqs_queue.fifo and not message_group_id:  # type: ignore
             raise Exception("When using a fifo queue argument: 'message_group_id' must be specified.")
 
         self._function.add_event_source(

--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -174,6 +174,9 @@ class SqsToLambdaStage(DataStage):
             dead_letter_queue=self._dlq,
         )
 
+        if hasattr(sqs_queue, "fifo") and sqs_queue.fifo and not message_group_id:
+            raise Exception("When using a fifo queue argument: 'message_group_id' must be specified.")
+
         self._function.add_event_source(
             SqsEventSource(
                 queue=self._queue,

--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -174,7 +174,7 @@ class SqsToLambdaStage(DataStage):
             dead_letter_queue=self._dlq,
         )
 
-        if hasattr(sqs_queue, "fifo") and sqs_queue.fifo and not message_group_id:
+        if hasattr(sqs_queue, "fifo") and sqs_queue.fifo and not message_group_id: # type: ignore
             raise Exception("When using a fifo queue argument: 'message_group_id' must be specified.")
 
         self._function.add_event_source(

--- a/core/aws_ddk_core/stages/sqs_lambda.py
+++ b/core/aws_ddk_core/stages/sqs_lambda.py
@@ -119,7 +119,7 @@ class SqsToLambdaStage(DataStage):
 
         self._event_source: str = f"{id}-event-source"
         self._event_detail_type: str = f"{id}-event-type"
-        self._message_group_id: str = message_group_id
+        self._message_group_id = message_group_id
 
         if lambda_function:
             self._function = lambda_function

--- a/core/tests/unit/test_sqs_lambda_stage.py
+++ b/core/tests/unit/test_sqs_lambda_stage.py
@@ -15,6 +15,7 @@
 from pathlib import Path
 
 import aws_cdk as cdk
+import pytest
 from aws_cdk.assertions import Match, Template
 from aws_cdk.aws_lambda import Code, Function, LayerVersion, Runtime
 from aws_cdk.aws_sqs import Queue
@@ -302,3 +303,32 @@ def test_sqs_lambda_fifo(test_stack: BaseStack) -> None:
             ]
         },
     )
+
+
+def test_invalid_arguments(test_stack: BaseStack) -> None:
+    with pytest.raises(Exception):
+        SqsToLambdaStage(
+            scope=test_stack,
+            id="dummy-sqs-lambda-0",
+            environment_id="dev",
+            code=Code.from_asset(f"{Path(__file__).parents[2]}"),
+            handler="commons.handlers.lambda_handler",
+            sqs_queue=SQSFactory.queue(
+                scope=test_stack,
+                environment_id="dev",
+                id="dummy-queue-0",
+                queue_name="dummy-queue.fifo",
+            ),
+        )
+    with pytest.raises(ValueError):
+        SqsToLambdaStage(
+            scope=test_stack,
+            id="dummy-sqs-lambda-1",
+            environment_id="dev",
+            sqs_queue=SQSFactory.queue(
+                scope=test_stack,
+                environment_id="dev",
+                id="dummy-queue-1",
+                queue_name="dummy-queue",
+            ),
+        )


### PR DESCRIPTION
### Enhancement
- `SqsToLambdaStage` Adding support for fifo event target 

### Detail
- Adding argument `message_group_id` which is required to set up an SQS event target when the queue is a **_fifo_** queue.

### Relates
- #183 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
