### PR TITLE
Enhancing AthenaSQLStage to handle both static and dynamic SQL Queries

### DIFF
--- a/core/aws_ddk_core/stages/athena_sql.py
+++ b/core/aws_ddk_core/stages/athena_sql.py
@@ -154,11 +154,8 @@ class AthenaSQLStage(StateMachineStage):
         return [
             SfnStateMachine(
                 self.state_machine,
-                input=RuleTargetInput.from_object(self._state_machine_input),
-            )
-            if self._query_string
-            else SfnStateMachine(
-                self.state_machine,
-                input=RuleTargetInput.from_event_path(self._event_bridge_event_path),
+                input=RuleTargetInput.from_object(self._state_machine_input)
+                if self._query_string
+                else RuleTargetInput.from_event_path(self._event_bridge_event_path),
             )
         ]

--- a/core/aws_ddk_core/stages/athena_sql.py
+++ b/core/aws_ddk_core/stages/athena_sql.py
@@ -99,21 +99,29 @@ class AthenaSQLStage(StateMachineStage):
         super().__init__(scope, id)
 
         if query_string and query_string_path:
-            raise Exception("For this stage provide one of query_string or query_string_path parameter, not both")
+            raise Exception(
+                "For this stage provide one of query_string or query_string_path parameter, not both"
+            )
 
         if query_string is None and query_string_path is None:
-            raise Exception("For this stage one of query_string or query_string_path parameter is required")
+            raise Exception(
+                "For this stage one of query_string or query_string_path parameter is required"
+            )
 
         self._event_detail_type: str = f"{id}-event-type"
         self._query_string = query_string
         self._state_machine_input = state_machine_input
-        self._event_bridge_event_path: Optional[str] = "$.detail" if query_string_path else None
+        self._event_bridge_event_path: Optional[str] = (
+            "$.detail" if query_string_path else None
+        )
 
         # Create AthenaStartQueryExecution step function task
         start_query_exec: AthenaStartQueryExecution = AthenaStartQueryExecution(
             self,
             "start-query-exec",
-            query_string=query_string if query_string else JsonPath.string_at(query_string_path),
+            query_string=query_string
+            if query_string
+            else JsonPath.string_at(query_string_path),
             integration_pattern=IntegrationPattern.RUN_JOB,
             query_execution_context=QueryExecutionContext(
                 catalog_name=catalog_name if catalog_name else None,
@@ -153,7 +161,13 @@ class AthenaSQLStage(StateMachineStage):
 
     def get_targets(self) -> Optional[List[IRuleTarget]]:
         return [
-            SfnStateMachine(self.state_machine, input=RuleTargetInput.from_object(self._state_machine_input),)
+            SfnStateMachine(
+                self.state_machine,
+                input=RuleTargetInput.from_object(self._state_machine_input),
+            )
             if self._query_string
-            else SfnStateMachine(self.state_machine, input=RuleTargetInput.from_event_path(self._event_bridge_event_path),)
+            else SfnStateMachine(
+                self.state_machine,
+                input=RuleTargetInput.from_event_path(self._event_bridge_event_path),
+            )
         ]

--- a/core/aws_ddk_core/stages/athena_sql.py
+++ b/core/aws_ddk_core/stages/athena_sql.py
@@ -99,29 +99,21 @@ class AthenaSQLStage(StateMachineStage):
         super().__init__(scope, id)
 
         if query_string and query_string_path:
-            raise Exception(
-                "For this stage provide one of query_string or query_string_path parameter, not both"
-            )
+            raise ValueError("For this stage provide one of query_string or query_string_path parameter, not both")
 
         if query_string is None and query_string_path is None:
-            raise Exception(
-                "For this stage one of query_string or query_string_path parameter is required"
-            )
+            raise ValueError("For this stage one of query_string or query_string_path parameter is required")
 
         self._event_detail_type: str = f"{id}-event-type"
         self._query_string = query_string
         self._state_machine_input = state_machine_input
-        self._event_bridge_event_path: Optional[str] = (
-            "$.detail" if query_string_path else None
-        )
+        self._event_bridge_event_path: Optional[str] = "$.detail" if query_string_path else None
 
         # Create AthenaStartQueryExecution step function task
         start_query_exec: AthenaStartQueryExecution = AthenaStartQueryExecution(
             self,
             "start-query-exec",
-            query_string=query_string
-            if query_string
-            else JsonPath.string_at(query_string_path),
+            query_string=query_string if query_string else JsonPath.string_at(query_string_path),
             integration_pattern=IntegrationPattern.RUN_JOB,
             query_execution_context=QueryExecutionContext(
                 catalog_name=catalog_name if catalog_name else None,

--- a/core/aws_ddk_core/stages/athena_sql.py
+++ b/core/aws_ddk_core/stages/athena_sql.py
@@ -14,12 +14,12 @@
 
 from typing import Any, Dict, List, Optional
 
+from aws_cdk.aws_events import IRuleTarget, RuleTargetInput
+from aws_cdk.aws_events_targets import SfnStateMachine
 from aws_cdk.aws_iam import PolicyStatement
 from aws_cdk.aws_kms import Key
-from aws_cdk.aws_events_targets import SfnStateMachine
-from aws_cdk.aws_events import IRuleTarget, RuleTargetInput
 from aws_cdk.aws_s3 import Location
-from aws_cdk.aws_stepfunctions import IntegrationPattern, Succeed, JsonPath
+from aws_cdk.aws_stepfunctions import IntegrationPattern, JsonPath, Succeed
 from aws_cdk.aws_stepfunctions_tasks import (
     AthenaStartQueryExecution,
     EncryptionConfiguration,


### PR DESCRIPTION
### Enhancement
AthenaSQLStage to handle both static and dynamic SQL Queries

### Detail
Stage Enhanced to support both Static Queries (current case) and dynamic queries using statemachine json path to add the ability to run multiple queries using the same state machine

### Relates
(core): Athena_SQL Stage Update #203

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
