### PR TITLE
Enhancing GlueTransform Stage for Stepfunction Crawler Task Retry

### DIFF
--- a/core/aws_ddk_core/stages/glue_transform.py
+++ b/core/aws_ddk_core/stages/glue_transform.py
@@ -47,6 +47,9 @@ class GlueTransformStage(StateMachineStage):
         glue_crawler_args: Optional[Dict[str, Any]] = {},
         state_machine_input: Optional[Dict[str, Any]] = None,
         additional_role_policy_statements: Optional[List[PolicyStatement]] = None,
+        state_machine_retry_max_attempts: Optional[int] = 3,
+        state_machine_retry_backoff_rate: Optional[int] = 2,
+        state_machine_retry_interval: Optional[cdk.Duration] = cdk.Duration.seconds(1),
         state_machine_failed_executions_alarm_threshold: Optional[int] = 1,
         state_machine_failed_executions_alarm_evaluation_periods: Optional[int] = 1,
     ) -> None:
@@ -90,6 +93,15 @@ class GlueTransformStage(StateMachineStage):
             The input dict to the state machine
         additional_role_policy_statements : Optional[List[PolicyStatement]]
             Additional IAM policy statements to add to the state machine role
+        state_machine_retry_max_attempts: Optional[int],
+            How many times to retry this particular error.
+            Defaults to `3`
+        state_machine_retry_backoff_rate: Optional[int]
+            Multiplication for how much longer the wait interval gets on every retry.
+            Defaults to `2`
+        state_machine_retry_interval: Optional[cdk.Duration]
+            How many seconds to wait initially before retrying.
+            Defaults to `cdk.Duration.seconds(1)`
         state_machine_failed_executions_alarm_threshold: Optional[int]
             The number of failed state machine executions before triggering CW alarm. Defaults to `1`
         state_machine_failed_executions_alarm_evaluation_periods: Optional[int]
@@ -155,8 +167,15 @@ class GlueTransformStage(StateMachineStage):
             },
             iam_resources=[crawler_arn],
         )
+
         success = Succeed(self, "success")
-        crawl_object.add_catch(success, errors=["Glue.CrawlerRunningException"])
+
+        crawl_object.add_retry(
+            errors=["Glue.CrawlerRunningException"],
+            max_attempts=state_machine_retry_max_attempts,
+            backoff_rate=state_machine_retry_backoff_rate,
+            interval=state_machine_retry_interval,
+        )
 
         # Build state machine
         self.build_state_machine(

--- a/core/aws_ddk_core/stages/glue_transform.py
+++ b/core/aws_ddk_core/stages/glue_transform.py
@@ -45,6 +45,7 @@ class GlueTransformStage(StateMachineStage):
         job_args: Optional[Dict[str, Any]] = None,
         glue_job_args: Optional[Dict[str, Any]] = {},
         glue_crawler_args: Optional[Dict[str, Any]] = {},
+        crawler_allow_failure: Optional[bool] = True,
         state_machine_input: Optional[Dict[str, Any]] = None,
         additional_role_policy_statements: Optional[List[PolicyStatement]] = None,
         state_machine_retry_max_attempts: Optional[int] = 3,
@@ -89,6 +90,9 @@ class GlueTransformStage(StateMachineStage):
         glue_crawler_args: Optional[Dict[str, Any]]
             Additional arguments to pass to CDK L1 Construct: `CfnCrawler`.
             See: https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_glue/CfnCrawler.html
+        crawler_allow_failure: Optional[Bool]
+            Argument to allow step function success in case of crawler failures and execption such as Glue.CrawlerRunningException
+            Defaults to `True`
         state_machine_input : Optional[Dict[str, Any]]
             The input dict to the state machine
         additional_role_policy_statements : Optional[List[PolicyStatement]]
@@ -97,10 +101,10 @@ class GlueTransformStage(StateMachineStage):
             How many times to retry this particular error.
             Defaults to `3`
         state_machine_retry_backoff_rate: Optional[int]
-            Multiplication for how much longer the wait interval gets on every retry.
+            Multiplication for how much longer the wait interval gets on every retry. 
             Defaults to `2`
         state_machine_retry_interval: Optional[cdk.Duration]
-            How many seconds to wait initially before retrying.
+            How many seconds to wait initially before retrying. 
             Defaults to `cdk.Duration.seconds(1)`
         state_machine_failed_executions_alarm_threshold: Optional[int]
             The number of failed state machine executions before triggering CW alarm. Defaults to `1`
@@ -176,6 +180,9 @@ class GlueTransformStage(StateMachineStage):
             backoff_rate=state_machine_retry_backoff_rate,
             interval=state_machine_retry_interval,
         )
+
+        if crawler_allow_failure:
+            crawl_object.add_catch(success, errors=["Glue.CrawlerRunningException"])
 
         # Build state machine
         self.build_state_machine(

--- a/core/aws_ddk_core/stages/glue_transform.py
+++ b/core/aws_ddk_core/stages/glue_transform.py
@@ -101,10 +101,10 @@ class GlueTransformStage(StateMachineStage):
             How many times to retry this particular error.
             Defaults to `3`
         state_machine_retry_backoff_rate: Optional[int]
-            Multiplication for how much longer the wait interval gets on every retry. 
+            Multiplication for how much longer the wait interval gets on every retry.
             Defaults to `2`
         state_machine_retry_interval: Optional[cdk.Duration]
-            How many seconds to wait initially before retrying. 
+            How many seconds to wait initially before retrying.
             Defaults to `cdk.Duration.seconds(1)`
         state_machine_failed_executions_alarm_threshold: Optional[int]
             The number of failed state machine executions before triggering CW alarm. Defaults to `1`

--- a/core/aws_ddk_core/stages/glue_transform.py
+++ b/core/aws_ddk_core/stages/glue_transform.py
@@ -91,7 +91,7 @@ class GlueTransformStage(StateMachineStage):
             Additional arguments to pass to CDK L1 Construct: `CfnCrawler`.
             See: https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_glue/CfnCrawler.html
         crawler_allow_failure: Optional[Bool]
-            Argument to allow step function success in case of crawler failures and execption such as Glue.CrawlerRunningException
+            Argument to allow stepfunction success for crawler failures/execption like Glue.CrawlerRunningException
             Defaults to `True`
         state_machine_input : Optional[Dict[str, Any]]
             The input dict to the state machine


### PR DESCRIPTION
**Enhancement**
Enhancing GlueTransform Stage for Stepfunction Crawler Task Retry

**Detail**
Added retries and backoff for the crawler task in step function so that it tries multiple time before failing, also instead of now catching the glue crawler running error and still succeeding the statemachine by design, it will now fail so CloudWatch can collect the right metric for alarm state

**Relates**
Enhancement: Enhancing GlueTransform Stage for Stepfunction Crawler Task Retry #206

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
