### PR TITLE
feat: appflow stage refactor

### DIFF
--- a/API.md
+++ b/API.md
@@ -111,7 +111,8 @@ Any object.
 | <code><a href="#aws-ddk-core.AppFlowIngestionStage.property.alarmsEnabled">alarmsEnabled</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#aws-ddk-core.AppFlowIngestionStage.property.cloudwatchAlarms">cloudwatchAlarms</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Alarm[]</code> | *No description.* |
 | <code><a href="#aws-ddk-core.AppFlowIngestionStage.property.stateMachine">stateMachine</a></code> | <code>aws-cdk-lib.aws_stepfunctions.StateMachine</code> | *No description.* |
-| <code><a href="#aws-ddk-core.AppFlowIngestionStage.property.flowObject">flowObject</a></code> | <code>aws-cdk-lib.aws_stepfunctions.CustomState</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AppFlowIngestionStage.property.flowName">flowName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.AppFlowIngestionStage.property.flowObject">flowObject</a></code> | <code>aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService</code> | *No description.* |
 
 ---
 
@@ -197,13 +198,23 @@ public readonly stateMachine: StateMachine;
 
 ---
 
+##### `flowName`<sup>Required</sup> <a name="flowName" id="aws-ddk-core.AppFlowIngestionStage.property.flowName"></a>
+
+```typescript
+public readonly flowName: string;
+```
+
+- *Type:* string
+
+---
+
 ##### `flowObject`<sup>Required</sup> <a name="flowObject" id="aws-ddk-core.AppFlowIngestionStage.property.flowObject"></a>
 
 ```typescript
-public readonly flowObject: CustomState;
+public readonly flowObject: CallAwsService;
 ```
 
-- *Type:* aws-cdk-lib.aws_stepfunctions.CustomState
+- *Type:* aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService
 
 ---
 

--- a/src/stages/appflow-ingestion.ts
+++ b/src/stages/appflow-ingestion.ts
@@ -96,7 +96,6 @@ export class AppFlowIngestionStage extends StateMachineStage {
       parameters: {
         FlowName: flowName,
       },
-      outputPath: "$.ExecutionId",
     });
     if (waitHandler) {
       task.addCatch(waitHandler, {

--- a/test/appflow-ingestion-stage.test.ts
+++ b/test/appflow-ingestion-stage.test.ts
@@ -17,8 +17,8 @@ test("AppFlow Ingestion stage creates State Machine, Lambda & Alarm", () => {
       "Fn::Join": [
         "",
         Match.arrayWith([
-          Match.stringLikeRegexp("start-flow-execution"),
-          Match.stringLikeRegexp("check-flow-execution-status"),
+          Match.stringLikeRegexp("Start Flow Execution"),
+          Match.stringLikeRegexp("Check Flow Execution Status"),
         ]),
       ],
     },
@@ -76,9 +76,7 @@ test("AppFlow Ingestion stage creates flow", () => {
     DefinitionString: {
       "Fn::Join": [
         "",
-        Match.arrayWith([
-          Match.stringLikeRegexp('"wait-before-checking-flow-status-again":{"Type":"Wait","Seconds":10'),
-        ]),
+        Match.arrayWith([Match.stringLikeRegexp('"Wait Before Checking Flow Status":{"Type":"Wait","Seconds":10')]),
       ],
     },
   });


### PR DESCRIPTION
- Replacing Start Flow step with `CallAwsService` instead of using Custom State
- Checking status will have to remain a custom lambda for now as 
```bash
appflow describe-flow-execution-records
``` 
doesn’t have a parameter for execution and query is not supported by the Amazon States Language.

### Relates
- #223 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
