### PR TITLE
fix: move `getEnvConfig()` to static method

### DIFF
--- a/API.md
+++ b/API.md
@@ -6436,6 +6436,45 @@ public readonly s3BucketProps: BucketProps;
 
 ---
 
+### GetEnvConfigProps <a name="GetEnvConfigProps" id="aws-ddk-core.GetEnvConfigProps"></a>
+
+#### Initializer <a name="Initializer" id="aws-ddk-core.GetEnvConfigProps.Initializer"></a>
+
+```typescript
+import { GetEnvConfigProps } from 'aws-ddk-core'
+
+const getEnvConfigProps: GetEnvConfigProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws-ddk-core.GetEnvConfigProps.property.configPath">configPath</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetEnvConfigProps.property.environmentId">environmentId</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `configPath`<sup>Required</sup> <a name="configPath" id="aws-ddk-core.GetEnvConfigProps.property.configPath"></a>
+
+```typescript
+public readonly configPath: string;
+```
+
+- *Type:* string
+
+---
+
+##### `environmentId`<sup>Required</sup> <a name="environmentId" id="aws-ddk-core.GetEnvConfigProps.property.environmentId"></a>
+
+```typescript
+public readonly environmentId: string;
+```
+
+- *Type:* string
+
+---
+
 ### GetSynthActionProps <a name="GetSynthActionProps" id="aws-ddk-core.GetSynthActionProps"></a>
 
 #### Initializer <a name="Initializer" id="aws-ddk-core.GetSynthActionProps.Initializer"></a>
@@ -8465,18 +8504,18 @@ new Configurator(scope: Construct, config: string | object, environmentId?: stri
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-ddk-core.Configurator.getEnvConfig">getEnvConfig</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.Configurator.getConfigAttribute">getConfigAttribute</a></code> | *No description.* |
 | <code><a href="#aws-ddk-core.Configurator.tagConstruct">tagConstruct</a></code> | *No description.* |
 
 ---
 
-##### `getEnvConfig` <a name="getEnvConfig" id="aws-ddk-core.Configurator.getEnvConfig"></a>
+##### `getConfigAttribute` <a name="getConfigAttribute" id="aws-ddk-core.Configurator.getConfigAttribute"></a>
 
 ```typescript
-public getEnvConfig(attribute: string): any
+public getConfigAttribute(attribute: string): any
 ```
 
-###### `attribute`<sup>Required</sup> <a name="attribute" id="aws-ddk-core.Configurator.getEnvConfig.parameter.attribute"></a>
+###### `attribute`<sup>Required</sup> <a name="attribute" id="aws-ddk-core.Configurator.getConfigAttribute.parameter.attribute"></a>
 
 - *Type:* string
 
@@ -8500,6 +8539,27 @@ public tagConstruct(scope: Construct, tags: {[ key: string ]: string}): void
 
 ---
 
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#aws-ddk-core.Configurator.getEnvConfig">getEnvConfig</a></code> | *No description.* |
+
+---
+
+##### `getEnvConfig` <a name="getEnvConfig" id="aws-ddk-core.Configurator.getEnvConfig"></a>
+
+```typescript
+import { Configurator } from 'aws-ddk-core'
+
+Configurator.getEnvConfig(props: GetEnvConfigProps)
+```
+
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.Configurator.getEnvConfig.parameter.props"></a>
+
+- *Type:* <a href="#aws-ddk-core.GetEnvConfigProps">GetEnvConfigProps</a>
+
+---
 
 #### Properties <a name="Properties" id="Properties"></a>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,6 @@ npm install projen
 npx projen test
 ```
 
-
 ### Integration Testing 
 The integration tests leverage the [`integ-runner` CLI ](https://github.com/aws/aws-cdk/tree/main/packages/%40aws-cdk/integ-runner)
 

--- a/src/cicd/pipelines.ts
+++ b/src/cicd/pipelines.ts
@@ -147,7 +147,7 @@ export class CICDPipelineStack extends BaseStack {
     if (this.pipeline === undefined) {
       throw new Error("`.buildPipeline()` needs to be called first before adding application stages to the pipeline.");
     }
-    const manualApprovals = props.manualApprovals ?? this.config.getEnvConfig("manual_approvals") ?? false;
+    const manualApprovals = props.manualApprovals ?? this.config.getConfigAttribute("manual_approvals") ?? false;
 
     if (manualApprovals) {
       this.pipeline?.addStage(props.stage, {
@@ -164,7 +164,7 @@ export class CICDPipelineStack extends BaseStack {
     if (this.pipeline === undefined) {
       throw new Error("`.buildPipeline()` needs to be called first before adding application stages to the pipeline.");
     }
-    const manualApprovals = props.manualApprovals ?? this.config.getEnvConfig("manual_approvals") ?? false;
+    const manualApprovals = props.manualApprovals ?? this.config.getConfigAttribute("manual_approvals") ?? false;
 
     var wave = new pipelines.Wave(props.stageId);
     if (manualApprovals) {
@@ -219,11 +219,11 @@ export class CICDPipelineStack extends BaseStack {
     }
 
     const topic =
-      this.environmentId && this.config.getEnvConfig("notifications_topic_arn")
+      this.environmentId && this.config.getConfigAttribute("notifications_topic_arn")
         ? sns.Topic.fromTopicArn(
             this,
             "ExecutionFailedNotifications",
-            this.config.getEnvConfig("notifications_topic_arn"),
+            this.config.getConfigAttribute("notifications_topic_arn"),
           )
         : new sns.Topic(this, "ExecutionFailedNotifications");
     this.notificationRule =

--- a/src/config/configurator.ts
+++ b/src/config/configurator.ts
@@ -48,15 +48,6 @@ export function getConfig(props: getConfigProps): any {
   return configData;
 }
 
-interface getEnvConfigProps {
-  readonly config?: string | object;
-  readonly environmentId: string;
-}
-export function getEnvConfig(props: getEnvConfigProps): any {
-  const config = getConfig({ config: props.config });
-  return config[props.environmentId];
-}
-
 interface getStackSynthesizerProps {
   readonly config?: string | object;
   readonly environmentId: string;
@@ -128,7 +119,15 @@ class ConfiguratorAspect implements cdk.IAspect {
   }
 }
 
+export interface GetEnvConfigProps {
+  readonly configPath: string;
+  readonly environmentId: string;
+}
+
 export class Configurator {
+  public static getEnvConfig(props: GetEnvConfigProps): any {
+    return getConfig({ config: props.configPath })[props.environmentId];
+  }
   public readonly config: any;
   public readonly environmentId?: string;
   constructor(scope: constructs.Construct, config: string | object, environmentId?: string) {
@@ -175,7 +174,7 @@ export class Configurator {
       Object.entries(tags).forEach(([key, value]) => cdk.Tags.of(scope).add(key, value));
     }
   }
-  getEnvConfig(attribute: string): any {
+  getConfigAttribute(attribute: string): any {
     return this.environmentId && this.config[this.environmentId] && this.config[this.environmentId][attribute]
       ? this.config[this.environmentId][attribute]
       : undefined;


### PR DESCRIPTION
We now have two ways of retrieving data from config.

1. Class method

```javascript
// Instantiate Config
const config = new Configurator({ configPath: "./ddk.yaml", environmentId: "dev" });

// Retrive Values from Object
config.getConfigAttribute("foo")
```

2. `static` method -- no object state 
```javascript
// Retrieve data directly from file
const config = Configurator.getEnvConfig({ configPath: "./test/test-config.yaml", environmentId: "dev" });
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
