### PR TITLE
fix: Change default for `state_machine_input` to undefined

### DIFF
--- a/src/pipelines/stage.ts
+++ b/src/pipelines/stage.ts
@@ -102,7 +102,7 @@ export abstract class StateMachineStage extends DataStage {
       evaluationPeriods: props.stateMachineFailedExecutionsAlarmEvaluationPeriods,
     });
 
-    const stateMachineInput = props.stateMachineInput ?? {};
+    const stateMachineInput = props.stateMachineInput;
     const eventPattern = {
       source: ["aws.states"],
       detailType: ["Step Functions Execution Status Change"],


### PR DESCRIPTION
Change default for 'state_machine_input' to undefined

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
