### PR TITLE
fix: Don't create default glue job security config if a custom one is passed.

### DIFF
--- a/core/aws_ddk_core/resources/_glue.py
+++ b/core/aws_ddk_core/resources/_glue.py
@@ -53,6 +53,7 @@ class GlueFactory:
         description: Optional[str] = None,
         role: Optional[IRole] = None,
         security_configuration: Optional[glue.ISecurityConfiguration] = None,
+        security_configuration_name: Optional[str] = None,
         timeout: Optional[cdk.Duration] = None,
         worker_count: Optional[int] = None,
         worker_type: Optional[glue.WorkerType] = None,
@@ -89,6 +90,8 @@ class GlueFactory:
             The execution role of the Glue job
         security_configuration : Optional[ISecurityConfiguration]
             The security configuration of the Glue job. If None, a default configuration is used
+        security_configuration_name : Optional[str]
+            The name for the default security configuration. Ignored if a custom security_configuration is passed.
         timeout : Optional[Duration]
             The job execution time (in seconds) after which Glue terminates the job.
             `aws_cdk.Duration.seconds(3600)` by default.
@@ -136,10 +139,12 @@ class GlueFactory:
         return glue.Job(scope, id, **job_config_props)
 
     @staticmethod
-    def _get_security_config(scope: Construct, id: str) -> glue.SecurityConfiguration:
+    def _get_security_config(
+        scope: Construct, id: str, security_configuration_name: Optional[str] = None
+    ) -> glue.SecurityConfiguration:
         return glue.SecurityConfiguration(
             scope,
             f"{id}-security-config",
-            security_configuration_name=f"{id}-security-config",
+            security_configuration_name=security_configuration_name or f"{id}-security-config",
             s3_encryption=glue.S3Encryption(mode=glue.S3EncryptionMode.S3_MANAGED),
         )

--- a/core/aws_ddk_core/resources/_glue.py
+++ b/core/aws_ddk_core/resources/_glue.py
@@ -133,7 +133,10 @@ class GlueFactory:
             if value is not None:
                 job_config_props[key] = value
         # Otherwise use defaults
-        job_config_props.setdefault("security_configuration", GlueFactory._get_security_config(scope, id))
+        if not job_config_props.get("security_configuration", None):
+            job_config_props["security_configuration"] = GlueFactory._get_security_config(
+                scope, id, security_configuration_name
+            )
 
         _logger.debug(f"job_config_props: {job_config_props}")
         return glue.Job(scope, id, **job_config_props)

--- a/core/tests/unit/test_glue.py
+++ b/core/tests/unit/test_glue.py
@@ -22,9 +22,9 @@ def test_glue_job_security_config_default_args(test_stack: BaseStack) -> None:
     )
 
     environment_id = "dev"
-    job1 = GlueFactory.job(
+    GlueFactory.job(
         test_stack,
-        id=f"job-1",
+        id="job-1",
         environment_id=environment_id,
         job_name=f"myproject-{environment_id}-job1",
         executable=glue_job_details,
@@ -53,9 +53,9 @@ def test_glue_job_security_config_with_custom_name(test_stack: BaseStack) -> Non
     )
 
     environment_id = "dev"
-    job1 = GlueFactory.job(
+    GlueFactory.job(
         test_stack,
-        id=f"job-1",
+        id="job-1",
         environment_id=environment_id,
         job_name=f"myproject-{environment_id}-job1",
         executable=glue_job_details,
@@ -86,15 +86,15 @@ def test_glue_job_security_config_custom(test_stack: BaseStack) -> None:
 
     security_config = SecurityConfiguration(
         test_stack,
-        f"security-config",
+        "security-config",
         security_configuration_name="my-custom-security-config-name",
         s3_encryption=S3Encryption(mode=S3EncryptionMode.KMS),
     )
 
     environment_id = "dev"
-    job1 = GlueFactory.job(
+    GlueFactory.job(
         test_stack,
-        id=f"job-1",
+        id="job-1",
         environment_id=environment_id,
         job_name=f"myproject-{environment_id}-job1",
         executable=glue_job_details,

--- a/core/tests/unit/test_glue.py
+++ b/core/tests/unit/test_glue.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+from aws_cdk.assertions import Template
+from aws_cdk.aws_glue_alpha import (
+    Code,
+    GlueVersion,
+    JobExecutable,
+    PythonVersion,
+    S3Encryption,
+    S3EncryptionMode,
+    SecurityConfiguration,
+)
+from aws_ddk_core.base import BaseStack
+from aws_ddk_core.resources import GlueFactory
+
+
+def test_glue_job_security_config_default_args(test_stack: BaseStack) -> None:
+    glue_job_details = JobExecutable.python_etl(
+        glue_version=GlueVersion.V3_0,
+        python_version=PythonVersion.THREE,
+        script=Code.from_asset(f"{Path(__file__).absolute()}"),
+    )
+
+    environment_id = "dev"
+    job1 = GlueFactory.job(
+        test_stack,
+        id=f"job-1",
+        environment_id=environment_id,
+        job_name=f"myproject-{environment_id}-job1",
+        executable=glue_job_details,
+    )
+
+    template = Template.from_stack(test_stack)
+    template.has_resource_properties(
+        "AWS::Glue::SecurityConfiguration",
+        props={
+            "EncryptionConfiguration": {
+                "S3Encryptions": [
+                    {"S3EncryptionMode": "SSE-S3"},
+                ],
+            },
+            "Name": "job-1-security-config",
+        },
+    )
+    assert len(template.find_resources("AWS::Glue::SecurityConfiguration")) == 1
+
+
+def test_glue_job_security_config_with_custom_name(test_stack: BaseStack) -> None:
+    glue_job_details = JobExecutable.python_etl(
+        glue_version=GlueVersion.V3_0,
+        python_version=PythonVersion.THREE,
+        script=Code.from_asset(f"{Path(__file__).absolute()}"),
+    )
+
+    environment_id = "dev"
+    job1 = GlueFactory.job(
+        test_stack,
+        id=f"job-1",
+        environment_id=environment_id,
+        job_name=f"myproject-{environment_id}-job1",
+        executable=glue_job_details,
+        security_configuration_name="my-custom-security-config-name",
+    )
+
+    template = Template.from_stack(test_stack)
+    template.has_resource_properties(
+        "AWS::Glue::SecurityConfiguration",
+        props={
+            "EncryptionConfiguration": {
+                "S3Encryptions": [
+                    {"S3EncryptionMode": "SSE-S3"},
+                ],
+            },
+            "Name": "my-custom-security-config-name",
+        },
+    )
+    assert len(template.find_resources("AWS::Glue::SecurityConfiguration")) == 1
+
+
+def test_glue_job_security_config_custom(test_stack: BaseStack) -> None:
+    glue_job_details = JobExecutable.python_etl(
+        glue_version=GlueVersion.V3_0,
+        python_version=PythonVersion.THREE,
+        script=Code.from_asset(f"{Path(__file__).absolute()}"),
+    )
+
+    security_config = SecurityConfiguration(
+        test_stack,
+        f"security-config",
+        security_configuration_name="my-custom-security-config-name",
+        s3_encryption=S3Encryption(mode=S3EncryptionMode.KMS),
+    )
+
+    environment_id = "dev"
+    job1 = GlueFactory.job(
+        test_stack,
+        id=f"job-1",
+        environment_id=environment_id,
+        job_name=f"myproject-{environment_id}-job1",
+        executable=glue_job_details,
+        security_configuration=security_config,
+    )
+
+    template = Template.from_stack(test_stack)
+    template.has_resource_properties(
+        "AWS::Glue::SecurityConfiguration",
+        props={
+            "EncryptionConfiguration": {
+                "S3Encryptions": [
+                    {"S3EncryptionMode": "SSE-KMS"},
+                ],
+            },
+            "Name": "my-custom-security-config-name",
+        },
+    )
+    assert len(template.find_resources("AWS::Glue::SecurityConfiguration")) == 1


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Adds a check to avoid creating default glue security config is a custom one is provided.
- Adds a configuration parameter to `GlueFactory.job` function to configure name for default glue security config.

### Relates
- Issue 1: If you use multiple environments and not parametrize glue job id by environment_id, the default security config that is created is not unique despite job_name being unique. Example 
```python
job1 = GlueFactory.job(
            self, id=f"job-1",
            environment_id=environment_id,
            job_name=f"myproject-{self._environment_id}-job1",
            ....
        )
```
This creates a security config with name `job-1-security-config`. If you use multiple environments, causes issues due to name not being unique. Relevant [code snippet](https://github.com/awslabs/aws-ddk/blob/main/core/aws_ddk_core/resources/_glue.py#L143)

- Issue 2: If you pass custom security config, then the default config is created nevertheless. Example:
```python
job_security_config = glue.SecurityConfiguration(
            self, f"job-security-config",
            security_configuration_name=f"myproject-{self._environment_id}-job-1-security-config",
            s3_encryption=glue.S3Encryption(mode=glue.S3EncryptionMode.S3_MANAGED),
        )

job1 = GlueFactory.job(
            self, id=f"job-1",
            environment_id=environment_id,
            job_name=f"myproject-{self._environment_id}-job1",
            security_config=job_security_config
            ....
        )
```
Assuming "dev" environment, this creates both `myproject-dev-job-1-security-config` as well as default `job-1-security-config` because the the construct SecurityConfig is created unconditionally [here](https://github.com/awslabs/aws-ddk/blob/main/core/aws_ddk_core/resources/_glue.py#L133).

Thanks in advance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
