### PR TITLE
feat: `CICDPipelineStack()` updates

### DIFF
--- a/API.md
+++ b/API.md
@@ -1960,7 +1960,7 @@ The construct to start the search from.
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipelineName">pipelineName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.notificationRule">notificationRule</a></code> | <code>aws-cdk-lib.aws_codestarnotifications.NotificationRule</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipeline">pipeline</a></code> | <code>aws-cdk-lib.pipelines.CodePipeline</code> | *No description.* |
-| <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipelineKey">pipelineKey</a></code> | <code>constructs.IConstruct</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipelineKey">pipelineKey</a></code> | <code>aws-cdk-lib.aws_kms.CfnKey</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.sourceAction">sourceAction</a></code> | <code>aws-cdk-lib.pipelines.CodePipelineSource</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.synthAction">synthAction</a></code> | <code>aws-cdk-lib.pipelines.CodeBuildStep</code> | *No description.* |
 
@@ -2369,10 +2369,10 @@ public readonly pipeline: CodePipeline;
 ##### `pipelineKey`<sup>Optional</sup> <a name="pipelineKey" id="aws-ddk-core.CICDPipelineStack.property.pipelineKey"></a>
 
 ```typescript
-public readonly pipelineKey: IConstruct;
+public readonly pipelineKey: CfnKey;
 ```
 
-- *Type:* constructs.IConstruct
+- *Type:* aws-cdk-lib.aws_kms.CfnKey
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1953,6 +1953,7 @@ The construct to start the search from.
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.nestedStackParent">nestedStackParent</a></code> | <code>aws-cdk-lib.Stack</code> | If this is a nested stack, returns it's parent stack. |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.nestedStackResource">nestedStackResource</a></code> | <code>aws-cdk-lib.CfnResource</code> | If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource. |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether termination protection is enabled for this stack. |
+| <code><a href="#aws-ddk-core.CICDPipelineStack.property.cdkLanguage">cdkLanguage</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.config">config</a></code> | <code><a href="#aws-ddk-core.Configurator">Configurator</a></code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.environmentId">environmentId</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStack.property.pipelineId">pipelineId</a></code> | <code>string</code> | *No description.* |
@@ -2292,6 +2293,16 @@ public readonly terminationProtection: boolean;
 - *Type:* boolean
 
 Whether termination protection is enabled for this stack.
+
+---
+
+##### `cdkLanguage`<sup>Required</sup> <a name="cdkLanguage" id="aws-ddk-core.CICDPipelineStack.property.cdkLanguage"></a>
+
+```typescript
+public readonly cdkLanguage: string;
+```
+
+- *Type:* string
 
 ---
 
@@ -5726,6 +5737,7 @@ const cICDPipelineStackProps: CICDPipelineStackProps = { ... }
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.config">config</a></code> | <code>string \| object</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.environmentId">environmentId</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.permissionsBoundaryArn">permissionsBoundaryArn</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.cdkLanguage">cdkLanguage</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.pipelineName">pipelineName</a></code> | <code>string</code> | *No description.* |
 
 ---
@@ -5947,6 +5959,16 @@ public readonly environmentId: string;
 
 ```typescript
 public readonly permissionsBoundaryArn: string;
+```
+
+- *Type:* string
+
+---
+
+##### `cdkLanguage`<sup>Optional</sup> <a name="cdkLanguage" id="aws-ddk-core.CICDPipelineStackProps.property.cdkLanguage"></a>
+
+```typescript
+public readonly cdkLanguage: string;
 ```
 
 - *Type:* string

--- a/src/cicd/actions.ts
+++ b/src/cicd/actions.ts
@@ -48,11 +48,7 @@ export class CICDActions {
 
   public static getSynthAction(props: GetSynthActionProps): pipelines.CodeBuildStep {
     var installCommands;
-    installCommands = [
-      `npm install -g aws-cdk@${props.cdkVersion ? props.cdkVersion : "latest"}`,
-      "npm install || true",
-      "pip install -r requirements.txt",
-    ];
+    installCommands = [`npm install -g aws-cdk@${props.cdkVersion ? props.cdkVersion : "latest"}`];
 
     // if (all([codeArtifactRepository, codeArtifactDomain, codeArtifactDomainOwner])) {
     //   if (!rolePolicyStatements) {
@@ -62,7 +58,7 @@ export class CICDActions {
     //   install_commands.psuh(`aws codeartifact login --tool pip --repository ${codeArtifactRepository} --domain ${codeArtifactDomain} --domain-owner ${codeArtifactDomainOwner}`);
     // }
     if (props.additionalInstallCommands != undefined && props.additionalInstallCommands.length > 0) {
-      installCommands = installCommands.concat(props.additionalInstallCommands);
+      installCommands = installCommands.concat(props.additionalInstallCommands); // will need to be replaced with `npm install aws-ddk-core@${version}` when available
     }
     return new pipelines.CodeBuildStep("Synth", {
       input: props.codePipelineSource,
@@ -99,11 +95,8 @@ export class CICDActions {
 
   public static getTestsAction(
     fileSetProducer: pipelines.IFileSetProducer,
-    commands: string[] = ["./test.sh || true"],
-    installCommands: string[] = [
-      "pip install -r requirements-dev.txt || true",
-      "pip install -r requirements.txt || true",
-    ],
+    commands: string[] = ["./test.sh"],
+    installCommands: string[] = ["pip install -r requirements-dev.txt", "pip install -r requirements.txt"],
     stageName: string = "Tests",
   ) {
     return new pipelines.ShellStep(stageName, {

--- a/src/cicd/actions.ts
+++ b/src/cicd/actions.ts
@@ -51,7 +51,7 @@ export class CICDActions {
     installCommands = [
       `npm install -g aws-cdk@${props.cdkVersion ? props.cdkVersion : "latest"}`,
       "npm install || true",
-      "pip install -r requirements.txt || true",
+      "pip install -r requirements.txt",
     ];
 
     // if (all([codeArtifactRepository, codeArtifactDomain, codeArtifactDomainOwner])) {

--- a/src/cicd/actions.ts
+++ b/src/cicd/actions.ts
@@ -48,7 +48,11 @@ export class CICDActions {
 
   public static getSynthAction(props: GetSynthActionProps): pipelines.CodeBuildStep {
     var installCommands;
-    installCommands = [`npm install -g aws-cdk@${props.cdkVersion ? props.cdkVersion : "latest"}`];
+    installCommands = [
+      `npm install -g aws-cdk@${props.cdkVersion ? props.cdkVersion : "latest"}`,
+      "npm install || true",
+      "pip install -r requirements.txt",
+    ];
 
     // if (all([codeArtifactRepository, codeArtifactDomain, codeArtifactDomainOwner])) {
     //   if (!rolePolicyStatements) {
@@ -58,7 +62,7 @@ export class CICDActions {
     //   install_commands.psuh(`aws codeartifact login --tool pip --repository ${codeArtifactRepository} --domain ${codeArtifactDomain} --domain-owner ${codeArtifactDomainOwner}`);
     // }
     if (props.additionalInstallCommands != undefined && props.additionalInstallCommands.length > 0) {
-      installCommands = installCommands.concat(props.additionalInstallCommands); // will need to be replaced with `npm install aws-ddk-core@${version}` when available
+      installCommands = installCommands.concat(props.additionalInstallCommands);
     }
     return new pipelines.CodeBuildStep("Synth", {
       input: props.codePipelineSource,
@@ -95,8 +99,11 @@ export class CICDActions {
 
   public static getTestsAction(
     fileSetProducer: pipelines.IFileSetProducer,
-    commands: string[] = ["./test.sh"],
-    installCommands: string[] = ["pip install -r requirements-dev.txt", "pip install -r requirements.txt"],
+    commands: string[] = ["./test.sh || true"],
+    installCommands: string[] = [
+      "pip install -r requirements-dev.txt || true",
+      "pip install -r requirements.txt || true",
+    ],
     stageName: string = "Tests",
   ) {
     return new pipelines.ShellStep(stageName, {

--- a/src/cicd/actions.ts
+++ b/src/cicd/actions.ts
@@ -51,7 +51,7 @@ export class CICDActions {
     installCommands = [
       `npm install -g aws-cdk@${props.cdkVersion ? props.cdkVersion : "latest"}`,
       "npm install || true",
-      "pip install -r requirements.txt",
+      "pip install -r requirements.txt || true",
     ];
 
     // if (all([codeArtifactRepository, codeArtifactDomain, codeArtifactDomainOwner])) {

--- a/src/cicd/pipelines.ts
+++ b/src/cicd/pipelines.ts
@@ -127,11 +127,6 @@ export class CICDPipelineStack extends BaseStack {
   }
 
   addSynthAction(props: SynthActionProps = {}) {
-    const languageInstallCommand: any = {
-      typescript: "npm install",
-      python: "pip install -r requirements.txt",
-    };
-
     this.synthAction =
       props.synthAction ||
       CICDActions.getSynthAction({
@@ -144,9 +139,7 @@ export class CICDPipelineStack extends BaseStack {
         codeartifactRepository: props.codeartifactRepository,
         codeartifactDomain: props.codeartifactDomain,
         codeartifactDomainOwner: props.codeartifactDomainOwner,
-        additionalInstallCommands: props.additionalInstallCommands
-          ? [languageInstallCommand[this.cdkLanguage]].concat(props.additionalInstallCommands)
-          : [languageInstallCommand[this.cdkLanguage]],
+        additionalInstallCommands: props.additionalInstallCommands,
       });
     return this;
   }

--- a/src/cicd/pipelines.ts
+++ b/src/cicd/pipelines.ts
@@ -2,9 +2,10 @@ import * as cdk from "aws-cdk-lib";
 import * as codepipeline from "aws-cdk-lib/aws-codepipeline";
 import * as codestarnotifications from "aws-cdk-lib/aws-codestarnotifications";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as kms from "aws-cdk-lib/aws-kms";
 import * as sns from "aws-cdk-lib/aws-sns";
 import * as pipelines from "aws-cdk-lib/pipelines";
-import { Construct, IConstruct } from "constructs";
+import { Construct } from "constructs";
 import { CICDActions } from "./actions";
 import { toTitleCase } from "./utils";
 import { BaseStack, BaseStackProps } from "../base";
@@ -86,7 +87,7 @@ export class CICDPipelineStack extends BaseStack {
   readonly cdkLanguage: string;
   public notificationRule?: codestarnotifications.NotificationRule;
   public pipeline?: pipelines.CodePipeline;
-  public pipelineKey?: IConstruct;
+  public pipelineKey?: kms.CfnKey;
   public sourceAction?: pipelines.CodePipelineSource;
   public synthAction?: pipelines.CodeBuildStep;
 
@@ -260,11 +261,9 @@ export class CICDPipelineStack extends BaseStack {
 
   synth() {
     this.pipeline?.buildPipeline();
-    this.pipelineKey = this.pipeline?.pipeline.artifactBucket.encryptionKey?.node.defaultChild ?? undefined;
+    this.pipelineKey = this.pipeline?.pipeline.artifactBucket.encryptionKey?.node.defaultChild as kms.CfnKey;
+    this.pipelineKey.addPropertyOverride("EnableKeyRotation", true);
 
-    // if (this.pipelineKey) {
-    //   this.pipelineKey = true;
-    // }
     return this;
   }
 }

--- a/src/cicd/pipelines.ts
+++ b/src/cicd/pipelines.ts
@@ -127,6 +127,11 @@ export class CICDPipelineStack extends BaseStack {
   }
 
   addSynthAction(props: SynthActionProps = {}) {
+    const languageInstallCommand: any = {
+      typescript: "npm install",
+      python: "pip install -r requirements.txt",
+    };
+
     this.synthAction =
       props.synthAction ||
       CICDActions.getSynthAction({
@@ -139,7 +144,9 @@ export class CICDPipelineStack extends BaseStack {
         codeartifactRepository: props.codeartifactRepository,
         codeartifactDomain: props.codeartifactDomain,
         codeartifactDomainOwner: props.codeartifactDomainOwner,
-        additionalInstallCommands: props.additionalInstallCommands,
+        additionalInstallCommands: props.additionalInstallCommands
+          ? [languageInstallCommand[this.cdkLanguage]].concat(props.additionalInstallCommands)
+          : [languageInstallCommand[this.cdkLanguage]],
       });
     return this;
   }

--- a/test/cicd-pipeline-stack.test.ts
+++ b/test/cicd-pipeline-stack.test.ts
@@ -107,6 +107,9 @@ test("Basic CICDPipeline", () => {
   template.hasResourceProperties("AWS::CodePipeline::Pipeline", {
     Name: "dummy-pipeline",
   });
+  template.hasResourceProperties("AWS::KMS::Key", {
+    EnableKeyRotation: true,
+  });
 });
 
 test("CICDPipeline with manual approval set", () => {


### PR DESCRIPTION
-  allowing command failure in generic actions like `Synth` & `Tests` to support different cdk language `beforeInstall` commands
- enforce `EnableKeyRotation` in pipeline kms key


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
