### PR TITLE
chore: `Configurator()` resource id refactor

### DIFF
--- a/src/config/configurator.ts
+++ b/src/config/configurator.ts
@@ -116,7 +116,7 @@ class ConfiguratorAspect implements cdk.IAspect {
       node.addPropertyOverride(this.propertyName, this.propertyValue);
     }
 
-    const nodePathItemRegex = new RegExp(`^(.*\/)?(${this.resourceId})(\/.*)?$`);
+    const nodePathItemRegex = new RegExp(`^(.*\/)?(${this.resourceId}\/Resource)(\/.*)?$`);
 
     if (this.resourceId && cdk.CfnResource.isCfnResource(node) && nodePathItemRegex.test(node.node.path)) {
       node.addPropertyOverride(this.propertyName, this.propertyValue);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -66,6 +66,9 @@ test("Config Override Stage By Id", () => {
           "Process Function": {
             MemorySize: 1024,
           },
+          "Stage/Queue": {
+            VisibilityTimeout: 300,
+          },
         },
       },
     },
@@ -85,12 +88,24 @@ test("Config Override Stage By Id", () => {
     },
   });
 
+  new SqsToLambdaStage(stack, "Stage2", {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(path.join(__dirname, "/../src/")),
+      handler: "commons.handlers.lambda_handler",
+      runtime: lambda.Runtime.PYTHON_3_9,
+    },
+  });
+
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::Lambda::Function", {
     MemorySize: 1024,
   });
   template.hasResourceProperties("AWS::SQS::Queue", {
     MemorySize: Match.absent(),
+    VisibilityTimeout: 300,
+  });
+  template.hasResourceProperties("AWS::SQS::Queue", {
+    VisibilityTimeout: 120,
   });
 });
 


### PR DESCRIPTION
### Enhancement
- Updates `Configurator()` functionality to update resources with paths matching specified `${id}/Resource`
- User will need to provide a subpath that matches a given resource's cdk metadata path but will not need to specify `/Resource` as this would override resource's that are created in addition to primary resources (e.g. Default Iam Policies, Event Sources etc)

An id of `Process Function` would match the following pattern and not the others.
<img width="863" alt="Screen Shot 2023-03-27 at 3 29 08 PM" src="https://user-images.githubusercontent.com/6465221/228084491-62544477-7097-4d7f-b133-37b5831b4f89.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
