### PR TITLE
chore: incrementing upper bound python version -> `<3.12`

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7.1, <3.11"
+python = ">=3.7.1, <3.12"
 boto3 = "^1.24.11"
 botocore = "^1.23.37"
 click = "^8.0.3"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7.1, <3.11"
+python = ">=3.7.1, <3.12"
 boto3 = "^1.24.11"
 boto3-stubs-lite = {version = "*", extras = ["lambda"]}
 botocore = "^1.27.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7.1, <3.11"
+python = ">=3.7.1, <3.12"
 mypy = "0.931"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
- Allows use of python 3.11.x with the AWS DDK. Unit tests and basic integration are passing using `3.11.1`
- Closes #288 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
