### PR TITLE
feat: `getEnvironment()`

### DIFF
--- a/API.md
+++ b/API.md
@@ -9522,6 +9522,7 @@ public tagConstruct(scope: Construct, tags: {[ key: string ]: string}): void
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#aws-ddk-core.Configurator.getEnvConfig">getEnvConfig</a></code> | *No description.* |
+| <code><a href="#aws-ddk-core.Configurator.getEnvironment">getEnvironment</a></code> | *No description.* |
 | <code><a href="#aws-ddk-core.Configurator.getTags">getTags</a></code> | *No description.* |
 
 ---
@@ -9535,6 +9536,20 @@ Configurator.getEnvConfig(props: GetEnvConfigProps)
 ```
 
 ###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.Configurator.getEnvConfig.parameter.props"></a>
+
+- *Type:* <a href="#aws-ddk-core.GetEnvConfigProps">GetEnvConfigProps</a>
+
+---
+
+##### `getEnvironment` <a name="getEnvironment" id="aws-ddk-core.Configurator.getEnvironment"></a>
+
+```typescript
+import { Configurator } from 'aws-ddk-core'
+
+Configurator.getEnvironment(props: GetEnvConfigProps)
+```
+
+###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.Configurator.getEnvironment.parameter.props"></a>
 
 - *Type:* <a href="#aws-ddk-core.GetEnvConfigProps">GetEnvConfigProps</a>
 

--- a/API.md
+++ b/API.md
@@ -7207,6 +7207,45 @@ public readonly environmentId: string;
 
 ---
 
+### GetEnvironmentProps <a name="GetEnvironmentProps" id="aws-ddk-core.GetEnvironmentProps"></a>
+
+#### Initializer <a name="Initializer" id="aws-ddk-core.GetEnvironmentProps.Initializer"></a>
+
+```typescript
+import { GetEnvironmentProps } from 'aws-ddk-core'
+
+const getEnvironmentProps: GetEnvironmentProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws-ddk-core.GetEnvironmentProps.property.configPath">configPath</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-ddk-core.GetEnvironmentProps.property.environmentId">environmentId</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `configPath`<sup>Required</sup> <a name="configPath" id="aws-ddk-core.GetEnvironmentProps.property.configPath"></a>
+
+```typescript
+public readonly configPath: string;
+```
+
+- *Type:* string
+
+---
+
+##### `environmentId`<sup>Optional</sup> <a name="environmentId" id="aws-ddk-core.GetEnvironmentProps.property.environmentId"></a>
+
+```typescript
+public readonly environmentId: string;
+```
+
+- *Type:* string
+
+---
+
 ### GetSynthActionProps <a name="GetSynthActionProps" id="aws-ddk-core.GetSynthActionProps"></a>
 
 #### Initializer <a name="Initializer" id="aws-ddk-core.GetSynthActionProps.Initializer"></a>
@@ -9546,12 +9585,12 @@ Configurator.getEnvConfig(props: GetEnvConfigProps)
 ```typescript
 import { Configurator } from 'aws-ddk-core'
 
-Configurator.getEnvironment(props: GetEnvConfigProps)
+Configurator.getEnvironment(props: GetEnvironmentProps)
 ```
 
 ###### `props`<sup>Required</sup> <a name="props" id="aws-ddk-core.Configurator.getEnvironment.parameter.props"></a>
 
-- *Type:* <a href="#aws-ddk-core.GetEnvConfigProps">GetEnvConfigProps</a>
+- *Type:* <a href="#aws-ddk-core.GetEnvironmentProps">GetEnvironmentProps</a>
 
 ---
 

--- a/src/config/configurator.ts
+++ b/src/config/configurator.ts
@@ -48,6 +48,18 @@ export function getConfig(props: getConfigProps): any {
   return configData;
 }
 
+export function getEnvironment(config: object | string, environmentId?: string): any {
+  const configData = getConfig({ config: config });
+  return configData.environments && environmentId
+    ? {
+        env: {
+          account: configData.environments[environmentId].account,
+          region: configData.environments[environmentId].region,
+        },
+      }
+    : { env: { account: configData.account, region: configData.region } };
+}
+
 interface getStackSynthesizerProps {
   readonly config?: string | object;
   readonly environmentId: string;
@@ -148,6 +160,17 @@ export class Configurator {
       : config.tags
       ? config.tags
       : {};
+  }
+  public static getEnvironment(props: GetEnvConfigProps): any {
+    const config = getConfig({ config: props.configPath });
+    return config.environments
+      ? {
+          env: {
+            account: config.environments[props.environmentId].account,
+            region: config.environments[props.environmentId].region,
+          },
+        }
+      : undefined;
   }
   public readonly config: any;
   public readonly environmentId?: string;

--- a/src/config/configurator.ts
+++ b/src/config/configurator.ts
@@ -146,6 +146,11 @@ export interface GetTagsProps {
   readonly environmentId?: string;
 }
 
+export interface GetEnvironmentProps {
+  readonly configPath: string;
+  readonly environmentId?: string;
+}
+
 export class Configurator {
   public static getEnvConfig(props: GetEnvConfigProps): any {
     const config = getConfig({ config: props.configPath });
@@ -161,16 +166,21 @@ export class Configurator {
       ? config.tags
       : {};
   }
-  public static getEnvironment(props: GetEnvConfigProps): any {
+  public static getEnvironment(props: GetEnvironmentProps): any {
     const config = getConfig({ config: props.configPath });
-    return config.environments
+    return config.environments && props.environmentId
       ? {
           env: {
             account: config.environments[props.environmentId].account,
             region: config.environments[props.environmentId].region,
           },
         }
-      : undefined;
+      : {
+          env: {
+            account: config.account,
+            region: config.region,
+          },
+        };
   }
   public readonly config: any;
   public readonly environmentId?: string;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -456,6 +456,15 @@ test("Get Environment", () => {
   assert(getEnvironment("./test/test-config.json", "dev").region === "us-east-1");
   assert(getEnvironment("./test/test-config.json").account === "111111111111");
   assert(getEnvironment("./test/test-config.json").region === "us-east-1");
+  assert(
+    Configurator.getEnvironment({ configPath: "./test/test-config.json", environmentId: "dev" }).account ===
+      "222222222222",
+  );
+  assert(
+    Configurator.getEnvironment({ configPath: "./test/test-config.json", environmentId: "dev" }).region === "us-east-1",
+  );
+  assert(Configurator.getEnvironment({ configPath: "./test/test-config.json" }).account === "111111111111");
+  assert(Configurator.getEnvironment({ configPath: "./test/test-config.json" }).region === "us-east-1");
   const app = new cdk.App();
   new cdk.Stack(app, "MyTestStack", {
     ...getEnvironment("./test/test-config.json"),

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -15,6 +15,7 @@ import {
   SqsToLambdaStage,
   getConfig,
   getStackSynthesizer,
+  getEnvironment,
 } from "../src";
 
 test("Config Simple Override", () => {
@@ -448,6 +449,17 @@ test("Get Config : Non-Existent File", () => {
 test("Get Env Config", () => {
   assert(getConfig({ config: "./test/test-config.json" }).environments.dev.account === "222222222222");
   assert(getConfig({}) === undefined);
+});
+
+test("Get Environment", () => {
+  assert(getEnvironment("./test/test-config.json", "dev").account === "222222222222");
+  assert(getEnvironment("./test/test-config.json", "dev").region === "us-east-1");
+  assert(getEnvironment("./test/test-config.json").account === "111111111111");
+  assert(getEnvironment("./test/test-config.json").region === "us-east-1");
+  const app = new cdk.App();
+  new cdk.Stack(app, "MyTestStack", {
+    ...getEnvironment("./test/test-config.json"),
+  });
 });
 
 test("Get Env Config Static Method", () => {

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -2,6 +2,8 @@
   "tags": {
     "global:foo": "bar"
   },
+  "account": "111111111111",
+  "region": "us-east-1",
   "environments": {
     "dev": {
       "account": "222222222222",


### PR DESCRIPTION
### Enhancement
- Simplify CDK environment pull from config with:
  - `getEnvironment()`
  - `Configurator.getEnvironment()`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
