### PR TITLE
chore: change return type of `getEnvironment` to `cdk.Environment`

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -130,6 +130,24 @@
         }
       ]
     },
+    "install": {
+      "name": "install",
+      "description": "Install project dependencies and update lockfile (non-frozen)",
+      "steps": [
+        {
+          "exec": "yarn install --check-files"
+        }
+      ]
+    },
+    "install:ci": {
+      "name": "install:ci",
+      "description": "Install project dependencies using frozen lockfile",
+      "steps": [
+        {
+          "exec": "yarn install --check-files --frozen-lockfile"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -130,24 +130,6 @@
         }
       ]
     },
-    "install": {
-      "name": "install",
-      "description": "Install project dependencies and update lockfile (non-frozen)",
-      "steps": [
-        {
-          "exec": "yarn install --check-files"
-        }
-      ]
-    },
-    "install:ci": {
-      "name": "install:ci",
-      "description": "Install project dependencies using frozen lockfile",
-      "steps": [
-        {
-          "exec": "yarn install --check-files --frozen-lockfile"
-        }
-      ]
-    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/API.md
+++ b/API.md
@@ -8133,45 +8133,6 @@ public readonly tags: {[ key: string ]: string};
 
 ---
 
-### EnvironmentResult <a name="EnvironmentResult" id="aws-ddk-core.EnvironmentResult"></a>
-
-#### Initializer <a name="Initializer" id="aws-ddk-core.EnvironmentResult.Initializer"></a>
-
-```typescript
-import { EnvironmentResult } from 'aws-ddk-core'
-
-const environmentResult: EnvironmentResult = { ... }
-```
-
-#### Properties <a name="Properties" id="Properties"></a>
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#aws-ddk-core.EnvironmentResult.property.account">account</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#aws-ddk-core.EnvironmentResult.property.region">region</a></code> | <code>string</code> | *No description.* |
-
----
-
-##### `account`<sup>Optional</sup> <a name="account" id="aws-ddk-core.EnvironmentResult.property.account"></a>
-
-```typescript
-public readonly account: string;
-```
-
-- *Type:* string
-
----
-
-##### `region`<sup>Optional</sup> <a name="region" id="aws-ddk-core.EnvironmentResult.property.region"></a>
-
-```typescript
-public readonly region: string;
-```
-
-- *Type:* string
-
----
-
 ### EventStageProps <a name="EventStageProps" id="aws-ddk-core.EventStageProps"></a>
 
 Properties for the event stage.

--- a/src/config/configurator.ts
+++ b/src/config/configurator.ts
@@ -82,12 +82,7 @@ export function getConfig(props: getConfigProps): Configuration | null {
   }
 }
 
-export interface EnvironmentResult {
-  readonly account?: string;
-  readonly region?: string;
-}
-
-export function getEnvironment(config: Configuration | string, environmentId?: string): EnvironmentResult {
+export function getEnvironment(config: Configuration | string, environmentId?: string): cdk.Environment {
   const configData = getConfig({ config: config });
 
   if (!configData) {
@@ -236,7 +231,7 @@ export class Configurator {
     return {};
   }
 
-  public static getEnvironment(props: GetEnvironmentProps): EnvironmentResult {
+  public static getEnvironment(props: GetEnvironmentProps): cdk.Environment {
     const config = getConfig({ config: props.configPath });
 
     if (!config) {


### PR DESCRIPTION
### Enhancment

### Detail
- change return type of `getEnvironment` to `cdk.Environment`
- Support use case of `CICDPipelineStack()`
```python
...
.add_stage(
        stage_id="dev",
        stage=ApplicationStage(
            app,
            "dev",
            env=Configurator.get_environment(
                config_path="./ddk.json", environment_id="dev"
            ),
        ),
    )
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
