### PR TITLE
fix: Adding failBuild parameter

### DIFF
--- a/API.md
+++ b/API.md
@@ -5819,8 +5819,21 @@ const addSecurityLintStageProps: AddSecurityLintStageProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#aws-ddk-core.AddSecurityLintStageProps.property.cfnNagFailBuild">cfnNagFailBuild</a></code> | <code>boolean</code> | Fail Codepipeline Build Action on failed results from CfnNag scan. |
 | <code><a href="#aws-ddk-core.AddSecurityLintStageProps.property.cloudAssemblyFileSet">cloudAssemblyFileSet</a></code> | <code>aws-cdk-lib.pipelines.IFileSetProducer</code> | Cloud assembly file set producer. |
 | <code><a href="#aws-ddk-core.AddSecurityLintStageProps.property.stageName">stageName</a></code> | <code>string</code> | Name of the stage. |
+
+---
+
+##### `cfnNagFailBuild`<sup>Optional</sup> <a name="cfnNagFailBuild" id="aws-ddk-core.AddSecurityLintStageProps.property.cfnNagFailBuild"></a>
+
+```typescript
+public readonly cfnNagFailBuild: boolean;
+```
+
+- *Type:* boolean
+
+Fail Codepipeline Build Action on failed results from CfnNag scan.
 
 ---
 
@@ -10804,7 +10817,7 @@ CICDActions.getBanditAction(codePipelineSource: CodePipelineSource, stageName?: 
 ```typescript
 import { CICDActions } from 'aws-ddk-core'
 
-CICDActions.getCfnNagAction(fileSetProducer: IFileSetProducer, stageName?: string)
+CICDActions.getCfnNagAction(fileSetProducer: IFileSetProducer, stageName?: string, failBuild?: boolean)
 ```
 
 ###### `fileSetProducer`<sup>Required</sup> <a name="fileSetProducer" id="aws-ddk-core.CICDActions.getCfnNagAction.parameter.fileSetProducer"></a>
@@ -10816,6 +10829,12 @@ CICDActions.getCfnNagAction(fileSetProducer: IFileSetProducer, stageName?: strin
 ###### `stageName`<sup>Optional</sup> <a name="stageName" id="aws-ddk-core.CICDActions.getCfnNagAction.parameter.stageName"></a>
 
 - *Type:* string
+
+---
+
+###### `failBuild`<sup>Optional</sup> <a name="failBuild" id="aws-ddk-core.CICDActions.getCfnNagAction.parameter.failBuild"></a>
+
+- *Type:* boolean
 
 ---
 

--- a/src/cicd/actions.ts
+++ b/src/cicd/actions.ts
@@ -80,7 +80,7 @@ export class CICDActions {
         FAIL_BUILD: failBuild ? "true" : "false",
       },
       commands: [
-        'cfn_nag_scan --input-path ./ && scan_result="SUCCESS" || echo scan_result="FAILED"',
+        'cfn_nag_scan --input-path ./ --template-pattern ".*.template.json" && scan_result="SUCCESS" || echo scan_result="FAILED"',
         'if [[ "$FAIL_BUILD" = "true" && "$scan_result" = "FAILED" ]]; then printf "\n\nFailing pipeline as possible insecure configurations were detected\n\n" && exit 1; fi',
       ],
     });

--- a/src/cicd/pipelines.ts
+++ b/src/cicd/pipelines.ts
@@ -115,6 +115,10 @@ export interface AddSecurityLintStageProps {
    * Cloud assembly file set producer.
    */
   readonly cloudAssemblyFileSet?: pipelines.IFileSetProducer;
+  /**
+   * Fail Codepipeline Build Action on failed results from CfnNag scan.
+   */
+  readonly cfnNagFailBuild?: boolean;
 }
 
 /**
@@ -455,7 +459,10 @@ export class CICDPipelineStack extends BaseStack {
     var cloudAssemblyFileSet = props.cloudAssemblyFileSet ?? this.pipeline?.cloudAssemblyFileSet;
 
     this.pipeline?.addWave(stageName, {
-      post: [CICDActions.getCfnNagAction(cloudAssemblyFileSet), CICDActions.getBanditAction(this.sourceAction)],
+      post: [
+        CICDActions.getCfnNagAction(cloudAssemblyFileSet, "CFNNag", props.cfnNagFailBuild),
+        CICDActions.getBanditAction(this.sourceAction),
+      ],
     });
 
     return this;


### PR DESCRIPTION
Fixes #130 

- Adds `failBuild` param to allow user to force codepipeline deployments to fail if CFNNag scans pick up violations.