### PR TITLE
feat: Update `StateMachineStage` to use `definitionBody` instead of deprecated `definition`

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -2,22 +2,22 @@
   "dependencies": [
     {
       "name": "@aws-cdk/aws-glue-alpha",
-      "version": "2.80.0-alpha.0",
+      "version": "2.85.0-alpha.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-kinesisfirehose-alpha",
-      "version": "2.80.0-alpha.0",
+      "version": "2.85.0-alpha.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-kinesisfirehose-destinations-alpha",
-      "version": "2.80.0-alpha.0",
+      "version": "2.85.0-alpha.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/integ-tests-alpha",
-      "version": "2.80.0-alpha.0",
+      "version": "2.85.0-alpha.0",
       "type": "build"
     },
     {
@@ -42,7 +42,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.80.0",
+      "version": "2.85.0",
       "type": "build"
     },
     {
@@ -144,22 +144,22 @@
     },
     {
       "name": "@aws-cdk/aws-glue-alpha",
-      "version": "2.80.0-alpha.0",
+      "version": "2.85.0-alpha.0",
       "type": "devenv"
     },
     {
       "name": "@aws-cdk/aws-kinesisfirehose-alpha",
-      "version": "2.80.0-alpha.0",
+      "version": "2.85.0-alpha.0",
       "type": "devenv"
     },
     {
       "name": "@aws-cdk/aws-kinesisfirehose-destinations-alpha",
-      "version": "2.80.0-alpha.0",
+      "version": "2.85.0-alpha.0",
       "type": "devenv"
     },
     {
       "name": "@aws-cdk/integ-tests-alpha",
-      "version": "2.80.0-alpha.0",
+      "version": "2.85.0-alpha.0",
       "type": "devenv"
     },
     {
@@ -174,27 +174,27 @@
     },
     {
       "name": "@aws-cdk/aws-glue-alpha",
-      "version": "^2.80.0-alpha.0",
+      "version": "^2.85.0-alpha.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-kinesisfirehose-alpha",
-      "version": "^2.80.0-alpha.0",
+      "version": "^2.85.0-alpha.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-kinesisfirehose-destinations-alpha",
-      "version": "^2.80.0-alpha.0",
+      "version": "^2.85.0-alpha.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/integ-tests-alpha",
-      "version": "^2.80.0-alpha.0",
+      "version": "^2.85.0-alpha.0",
       "type": "peer"
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.80.0",
+      "version": "^2.85.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,6 +1,6 @@
 const { awscdk, javascript, release, DependencyType } = require("projen");
 
-const CDK_VERSION = "2.80.0";
+const CDK_VERSION = "2.85.0";
 
 const project = new awscdk.AwsCdkConstructLibrary({
   author: "AWS Professional Services",

--- a/API.md
+++ b/API.md
@@ -6589,6 +6589,8 @@ const appFlowIngestionStageProps: AppFlowIngestionStageProps = { ... }
 | <code><a href="#aws-ddk-core.AppFlowIngestionStageProps.property.name">name</a></code> | <code>string</code> | Name of the stage. |
 | <code><a href="#aws-ddk-core.AppFlowIngestionStageProps.property.additionalRolePolicyStatements">additionalRolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | Additional IAM policy statements to add to the state machine role. |
 | <code><a href="#aws-ddk-core.AppFlowIngestionStageProps.property.alarmsEnabled">alarmsEnabled</a></code> | <code>boolean</code> | Enable/Disable all alarms in the stage. |
+| <code><a href="#aws-ddk-core.AppFlowIngestionStageProps.property.definition">definition</a></code> | <code>string \| aws-cdk-lib.aws_stepfunctions.IChainable</code> | Steps for the state machine. |
+| <code><a href="#aws-ddk-core.AppFlowIngestionStageProps.property.definitionFile">definitionFile</a></code> | <code>string</code> | File containing a JSON definition for the state machine. |
 | <code><a href="#aws-ddk-core.AppFlowIngestionStageProps.property.stateMachineFailedExecutionsAlarmEvaluationPeriods">stateMachineFailedExecutionsAlarmEvaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
 | <code><a href="#aws-ddk-core.AppFlowIngestionStageProps.property.stateMachineFailedExecutionsAlarmThreshold">stateMachineFailedExecutionsAlarmThreshold</a></code> | <code>number</code> | The number of failed state machine executions before triggering CW alarm. |
 | <code><a href="#aws-ddk-core.AppFlowIngestionStageProps.property.stateMachineInput">stateMachineInput</a></code> | <code>{[ key: string ]: any}</code> | Input of the state machine. |
@@ -6647,6 +6649,32 @@ public readonly alarmsEnabled: boolean;
 - *Default:* true
 
 Enable/Disable all alarms in the stage.
+
+---
+
+##### `definition`<sup>Optional</sup> <a name="definition" id="aws-ddk-core.AppFlowIngestionStageProps.property.definition"></a>
+
+```typescript
+public readonly definition: string | IChainable;
+```
+
+- *Type:* string | aws-cdk-lib.aws_stepfunctions.IChainable
+
+Steps for the state machine.
+
+Can either be provided as 'sfn.IChainable' or a JSON string.
+
+---
+
+##### `definitionFile`<sup>Optional</sup> <a name="definitionFile" id="aws-ddk-core.AppFlowIngestionStageProps.property.definitionFile"></a>
+
+```typescript
+public readonly definitionFile: string;
+```
+
+- *Type:* string
+
+File containing a JSON definition for the state machine.
 
 ---
 
@@ -6783,6 +6811,8 @@ const athenaToSQLStageProps: AthenaToSQLStageProps = { ... }
 | <code><a href="#aws-ddk-core.AthenaToSQLStageProps.property.name">name</a></code> | <code>string</code> | Name of the stage. |
 | <code><a href="#aws-ddk-core.AthenaToSQLStageProps.property.additionalRolePolicyStatements">additionalRolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | Additional IAM policy statements to add to the state machine role. |
 | <code><a href="#aws-ddk-core.AthenaToSQLStageProps.property.alarmsEnabled">alarmsEnabled</a></code> | <code>boolean</code> | Enable/Disable all alarms in the stage. |
+| <code><a href="#aws-ddk-core.AthenaToSQLStageProps.property.definition">definition</a></code> | <code>string \| aws-cdk-lib.aws_stepfunctions.IChainable</code> | Steps for the state machine. |
+| <code><a href="#aws-ddk-core.AthenaToSQLStageProps.property.definitionFile">definitionFile</a></code> | <code>string</code> | File containing a JSON definition for the state machine. |
 | <code><a href="#aws-ddk-core.AthenaToSQLStageProps.property.stateMachineFailedExecutionsAlarmEvaluationPeriods">stateMachineFailedExecutionsAlarmEvaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
 | <code><a href="#aws-ddk-core.AthenaToSQLStageProps.property.stateMachineFailedExecutionsAlarmThreshold">stateMachineFailedExecutionsAlarmThreshold</a></code> | <code>number</code> | The number of failed state machine executions before triggering CW alarm. |
 | <code><a href="#aws-ddk-core.AthenaToSQLStageProps.property.stateMachineInput">stateMachineInput</a></code> | <code>{[ key: string ]: any}</code> | Input of the state machine. |
@@ -6845,6 +6875,32 @@ public readonly alarmsEnabled: boolean;
 - *Default:* true
 
 Enable/Disable all alarms in the stage.
+
+---
+
+##### `definition`<sup>Optional</sup> <a name="definition" id="aws-ddk-core.AthenaToSQLStageProps.property.definition"></a>
+
+```typescript
+public readonly definition: string | IChainable;
+```
+
+- *Type:* string | aws-cdk-lib.aws_stepfunctions.IChainable
+
+Steps for the state machine.
+
+Can either be provided as 'sfn.IChainable' or a JSON string.
+
+---
+
+##### `definitionFile`<sup>Optional</sup> <a name="definitionFile" id="aws-ddk-core.AthenaToSQLStageProps.property.definitionFile"></a>
+
+```typescript
+public readonly definitionFile: string;
+```
+
+- *Type:* string
+
+File containing a JSON definition for the state machine.
 
 ---
 
@@ -7911,6 +7967,8 @@ const dataBrewTransformStageProps: DataBrewTransformStageProps = { ... }
 | <code><a href="#aws-ddk-core.DataBrewTransformStageProps.property.name">name</a></code> | <code>string</code> | Name of the stage. |
 | <code><a href="#aws-ddk-core.DataBrewTransformStageProps.property.additionalRolePolicyStatements">additionalRolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | Additional IAM policy statements to add to the state machine role. |
 | <code><a href="#aws-ddk-core.DataBrewTransformStageProps.property.alarmsEnabled">alarmsEnabled</a></code> | <code>boolean</code> | Enable/Disable all alarms in the stage. |
+| <code><a href="#aws-ddk-core.DataBrewTransformStageProps.property.definition">definition</a></code> | <code>string \| aws-cdk-lib.aws_stepfunctions.IChainable</code> | Steps for the state machine. |
+| <code><a href="#aws-ddk-core.DataBrewTransformStageProps.property.definitionFile">definitionFile</a></code> | <code>string</code> | File containing a JSON definition for the state machine. |
 | <code><a href="#aws-ddk-core.DataBrewTransformStageProps.property.stateMachineFailedExecutionsAlarmEvaluationPeriods">stateMachineFailedExecutionsAlarmEvaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
 | <code><a href="#aws-ddk-core.DataBrewTransformStageProps.property.stateMachineFailedExecutionsAlarmThreshold">stateMachineFailedExecutionsAlarmThreshold</a></code> | <code>number</code> | The number of failed state machine executions before triggering CW alarm. |
 | <code><a href="#aws-ddk-core.DataBrewTransformStageProps.property.stateMachineInput">stateMachineInput</a></code> | <code>{[ key: string ]: any}</code> | Input of the state machine. |
@@ -7985,6 +8043,32 @@ public readonly alarmsEnabled: boolean;
 - *Default:* true
 
 Enable/Disable all alarms in the stage.
+
+---
+
+##### `definition`<sup>Optional</sup> <a name="definition" id="aws-ddk-core.DataBrewTransformStageProps.property.definition"></a>
+
+```typescript
+public readonly definition: string | IChainable;
+```
+
+- *Type:* string | aws-cdk-lib.aws_stepfunctions.IChainable
+
+Steps for the state machine.
+
+Can either be provided as 'sfn.IChainable' or a JSON string.
+
+---
+
+##### `definitionFile`<sup>Optional</sup> <a name="definitionFile" id="aws-ddk-core.DataBrewTransformStageProps.property.definitionFile"></a>
+
+```typescript
+public readonly definitionFile: string;
+```
+
+- *Type:* string
+
+File containing a JSON definition for the state machine.
 
 ---
 
@@ -9188,6 +9272,8 @@ const glueTransformStageProps: GlueTransformStageProps = { ... }
 | <code><a href="#aws-ddk-core.GlueTransformStageProps.property.name">name</a></code> | <code>string</code> | Name of the stage. |
 | <code><a href="#aws-ddk-core.GlueTransformStageProps.property.additionalRolePolicyStatements">additionalRolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | Additional IAM policy statements to add to the state machine role. |
 | <code><a href="#aws-ddk-core.GlueTransformStageProps.property.alarmsEnabled">alarmsEnabled</a></code> | <code>boolean</code> | Enable/Disable all alarms in the stage. |
+| <code><a href="#aws-ddk-core.GlueTransformStageProps.property.definition">definition</a></code> | <code>string \| aws-cdk-lib.aws_stepfunctions.IChainable</code> | Steps for the state machine. |
+| <code><a href="#aws-ddk-core.GlueTransformStageProps.property.definitionFile">definitionFile</a></code> | <code>string</code> | File containing a JSON definition for the state machine. |
 | <code><a href="#aws-ddk-core.GlueTransformStageProps.property.stateMachineFailedExecutionsAlarmEvaluationPeriods">stateMachineFailedExecutionsAlarmEvaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
 | <code><a href="#aws-ddk-core.GlueTransformStageProps.property.stateMachineFailedExecutionsAlarmThreshold">stateMachineFailedExecutionsAlarmThreshold</a></code> | <code>number</code> | The number of failed state machine executions before triggering CW alarm. |
 | <code><a href="#aws-ddk-core.GlueTransformStageProps.property.stateMachineInput">stateMachineInput</a></code> | <code>{[ key: string ]: any}</code> | Input of the state machine. |
@@ -9253,6 +9339,32 @@ public readonly alarmsEnabled: boolean;
 - *Default:* true
 
 Enable/Disable all alarms in the stage.
+
+---
+
+##### `definition`<sup>Optional</sup> <a name="definition" id="aws-ddk-core.GlueTransformStageProps.property.definition"></a>
+
+```typescript
+public readonly definition: string | IChainable;
+```
+
+- *Type:* string | aws-cdk-lib.aws_stepfunctions.IChainable
+
+Steps for the state machine.
+
+Can either be provided as 'sfn.IChainable' or a JSON string.
+
+---
+
+##### `definitionFile`<sup>Optional</sup> <a name="definitionFile" id="aws-ddk-core.GlueTransformStageProps.property.definitionFile"></a>
+
+```typescript
+public readonly definitionFile: string;
+```
+
+- *Type:* string
+
+File containing a JSON definition for the state machine.
 
 ---
 
@@ -10073,6 +10185,8 @@ const mWAATriggerDagsStageProps: MWAATriggerDagsStageProps = { ... }
 | <code><a href="#aws-ddk-core.MWAATriggerDagsStageProps.property.name">name</a></code> | <code>string</code> | Name of the stage. |
 | <code><a href="#aws-ddk-core.MWAATriggerDagsStageProps.property.additionalRolePolicyStatements">additionalRolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | Additional IAM policy statements to add to the state machine role. |
 | <code><a href="#aws-ddk-core.MWAATriggerDagsStageProps.property.alarmsEnabled">alarmsEnabled</a></code> | <code>boolean</code> | Enable/Disable all alarms in the stage. |
+| <code><a href="#aws-ddk-core.MWAATriggerDagsStageProps.property.definition">definition</a></code> | <code>string \| aws-cdk-lib.aws_stepfunctions.IChainable</code> | Steps for the state machine. |
+| <code><a href="#aws-ddk-core.MWAATriggerDagsStageProps.property.definitionFile">definitionFile</a></code> | <code>string</code> | File containing a JSON definition for the state machine. |
 | <code><a href="#aws-ddk-core.MWAATriggerDagsStageProps.property.stateMachineFailedExecutionsAlarmEvaluationPeriods">stateMachineFailedExecutionsAlarmEvaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
 | <code><a href="#aws-ddk-core.MWAATriggerDagsStageProps.property.stateMachineFailedExecutionsAlarmThreshold">stateMachineFailedExecutionsAlarmThreshold</a></code> | <code>number</code> | The number of failed state machine executions before triggering CW alarm. |
 | <code><a href="#aws-ddk-core.MWAATriggerDagsStageProps.property.stateMachineInput">stateMachineInput</a></code> | <code>{[ key: string ]: any}</code> | Input of the state machine. |
@@ -10130,6 +10244,32 @@ public readonly alarmsEnabled: boolean;
 - *Default:* true
 
 Enable/Disable all alarms in the stage.
+
+---
+
+##### `definition`<sup>Optional</sup> <a name="definition" id="aws-ddk-core.MWAATriggerDagsStageProps.property.definition"></a>
+
+```typescript
+public readonly definition: string | IChainable;
+```
+
+- *Type:* string | aws-cdk-lib.aws_stepfunctions.IChainable
+
+Steps for the state machine.
+
+Can either be provided as 'sfn.IChainable' or a JSON string.
+
+---
+
+##### `definitionFile`<sup>Optional</sup> <a name="definitionFile" id="aws-ddk-core.MWAATriggerDagsStageProps.property.definitionFile"></a>
+
+```typescript
+public readonly definitionFile: string;
+```
+
+- *Type:* string
+
+File containing a JSON definition for the state machine.
 
 ---
 
@@ -10302,6 +10442,8 @@ const redshiftDataApiStageProps: RedshiftDataApiStageProps = { ... }
 | <code><a href="#aws-ddk-core.RedshiftDataApiStageProps.property.name">name</a></code> | <code>string</code> | Name of the stage. |
 | <code><a href="#aws-ddk-core.RedshiftDataApiStageProps.property.additionalRolePolicyStatements">additionalRolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | Additional IAM policy statements to add to the state machine role. |
 | <code><a href="#aws-ddk-core.RedshiftDataApiStageProps.property.alarmsEnabled">alarmsEnabled</a></code> | <code>boolean</code> | Enable/Disable all alarms in the stage. |
+| <code><a href="#aws-ddk-core.RedshiftDataApiStageProps.property.definition">definition</a></code> | <code>string \| aws-cdk-lib.aws_stepfunctions.IChainable</code> | Steps for the state machine. |
+| <code><a href="#aws-ddk-core.RedshiftDataApiStageProps.property.definitionFile">definitionFile</a></code> | <code>string</code> | File containing a JSON definition for the state machine. |
 | <code><a href="#aws-ddk-core.RedshiftDataApiStageProps.property.stateMachineFailedExecutionsAlarmEvaluationPeriods">stateMachineFailedExecutionsAlarmEvaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
 | <code><a href="#aws-ddk-core.RedshiftDataApiStageProps.property.stateMachineFailedExecutionsAlarmThreshold">stateMachineFailedExecutionsAlarmThreshold</a></code> | <code>number</code> | The number of failed state machine executions before triggering CW alarm. |
 | <code><a href="#aws-ddk-core.RedshiftDataApiStageProps.property.stateMachineInput">stateMachineInput</a></code> | <code>{[ key: string ]: any}</code> | Input of the state machine. |
@@ -10360,6 +10502,32 @@ public readonly alarmsEnabled: boolean;
 - *Default:* true
 
 Enable/Disable all alarms in the stage.
+
+---
+
+##### `definition`<sup>Optional</sup> <a name="definition" id="aws-ddk-core.RedshiftDataApiStageProps.property.definition"></a>
+
+```typescript
+public readonly definition: string | IChainable;
+```
+
+- *Type:* string | aws-cdk-lib.aws_stepfunctions.IChainable
+
+Steps for the state machine.
+
+Can either be provided as 'sfn.IChainable' or a JSON string.
+
+---
+
+##### `definitionFile`<sup>Optional</sup> <a name="definitionFile" id="aws-ddk-core.RedshiftDataApiStageProps.property.definitionFile"></a>
+
+```typescript
+public readonly definitionFile: string;
+```
+
+- *Type:* string
+
+File containing a JSON definition for the state machine.
 
 ---
 
@@ -11885,6 +12053,8 @@ const stateMachineStageProps: StateMachineStageProps = { ... }
 | <code><a href="#aws-ddk-core.StateMachineStageProps.property.name">name</a></code> | <code>string</code> | Name of the stage. |
 | <code><a href="#aws-ddk-core.StateMachineStageProps.property.additionalRolePolicyStatements">additionalRolePolicyStatements</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | Additional IAM policy statements to add to the state machine role. |
 | <code><a href="#aws-ddk-core.StateMachineStageProps.property.alarmsEnabled">alarmsEnabled</a></code> | <code>boolean</code> | Enable/Disable all alarms in the stage. |
+| <code><a href="#aws-ddk-core.StateMachineStageProps.property.definition">definition</a></code> | <code>string \| aws-cdk-lib.aws_stepfunctions.IChainable</code> | Steps for the state machine. |
+| <code><a href="#aws-ddk-core.StateMachineStageProps.property.definitionFile">definitionFile</a></code> | <code>string</code> | File containing a JSON definition for the state machine. |
 | <code><a href="#aws-ddk-core.StateMachineStageProps.property.stateMachineFailedExecutionsAlarmEvaluationPeriods">stateMachineFailedExecutionsAlarmEvaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
 | <code><a href="#aws-ddk-core.StateMachineStageProps.property.stateMachineFailedExecutionsAlarmThreshold">stateMachineFailedExecutionsAlarmThreshold</a></code> | <code>number</code> | The number of failed state machine executions before triggering CW alarm. |
 | <code><a href="#aws-ddk-core.StateMachineStageProps.property.stateMachineInput">stateMachineInput</a></code> | <code>{[ key: string ]: any}</code> | Input of the state machine. |
@@ -11938,6 +12108,32 @@ public readonly alarmsEnabled: boolean;
 - *Default:* true
 
 Enable/Disable all alarms in the stage.
+
+---
+
+##### `definition`<sup>Optional</sup> <a name="definition" id="aws-ddk-core.StateMachineStageProps.property.definition"></a>
+
+```typescript
+public readonly definition: string | IChainable;
+```
+
+- *Type:* string | aws-cdk-lib.aws_stepfunctions.IChainable
+
+Steps for the state machine.
+
+Can either be provided as 'sfn.IChainable' or a JSON string.
+
+---
+
+##### `definitionFile`<sup>Optional</sup> <a name="definitionFile" id="aws-ddk-core.StateMachineStageProps.property.definitionFile"></a>
+
+```typescript
+public readonly definitionFile: string;
+```
+
+- *Type:* string
+
+File containing a JSON definition for the state machine.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -7029,6 +7029,7 @@ const baseStackProps: BaseStackProps = { ... }
 | <code><a href="#aws-ddk-core.BaseStackProps.property.env">env</a></code> | <code>aws-cdk-lib.Environment</code> | The AWS environment (account/region) where this stack will be deployed. |
 | <code><a href="#aws-ddk-core.BaseStackProps.property.permissionsBoundary">permissionsBoundary</a></code> | <code>aws-cdk-lib.PermissionsBoundary</code> | Options for applying a permissions boundary to all IAM Roles and Users created within this Stage. |
 | <code><a href="#aws-ddk-core.BaseStackProps.property.stackName">stackName</a></code> | <code>string</code> | Name to deploy the stack with. |
+| <code><a href="#aws-ddk-core.BaseStackProps.property.suppressTemplateIndentation">suppressTemplateIndentation</a></code> | <code>boolean</code> | Enable this flag to suppress indentation in generated CloudFormation templates. |
 | <code><a href="#aws-ddk-core.BaseStackProps.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method to use while deploying this stack. |
 | <code><a href="#aws-ddk-core.BaseStackProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Stack tags that will be applied to all the taggable resources and the stack itself. |
 | <code><a href="#aws-ddk-core.BaseStackProps.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether to enable termination protection for this stack. |
@@ -7182,6 +7183,23 @@ Name to deploy the stack with.
 
 ---
 
+##### `suppressTemplateIndentation`<sup>Optional</sup> <a name="suppressTemplateIndentation" id="aws-ddk-core.BaseStackProps.property.suppressTemplateIndentation"></a>
+
+```typescript
+public readonly suppressTemplateIndentation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* the value of `@aws-cdk/core:suppressTemplateIndentation`, or `false` if that is not set.
+
+Enable this flag to suppress indentation in generated CloudFormation templates.
+
+If not specified, the value of the `@aws-cdk/core:suppressTemplateIndentation`
+context key will be used. If that is not specified, then the
+default value `false` will be used.
+
+---
+
 ##### `synthesizer`<sup>Optional</sup> <a name="synthesizer" id="aws-ddk-core.BaseStackProps.property.synthesizer"></a>
 
 ```typescript
@@ -7290,6 +7308,7 @@ const cICDPipelineStackProps: CICDPipelineStackProps = { ... }
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.env">env</a></code> | <code>aws-cdk-lib.Environment</code> | The AWS environment (account/region) where this stack will be deployed. |
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.permissionsBoundary">permissionsBoundary</a></code> | <code>aws-cdk-lib.PermissionsBoundary</code> | Options for applying a permissions boundary to all IAM Roles and Users created within this Stage. |
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.stackName">stackName</a></code> | <code>string</code> | Name to deploy the stack with. |
+| <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.suppressTemplateIndentation">suppressTemplateIndentation</a></code> | <code>boolean</code> | Enable this flag to suppress indentation in generated CloudFormation templates. |
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method to use while deploying this stack. |
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Stack tags that will be applied to all the taggable resources and the stack itself. |
 | <code><a href="#aws-ddk-core.CICDPipelineStackProps.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether to enable termination protection for this stack. |
@@ -7442,6 +7461,23 @@ public readonly stackName: string;
 - *Default:* Derived from construct path.
 
 Name to deploy the stack with.
+
+---
+
+##### `suppressTemplateIndentation`<sup>Optional</sup> <a name="suppressTemplateIndentation" id="aws-ddk-core.CICDPipelineStackProps.property.suppressTemplateIndentation"></a>
+
+```typescript
+public readonly suppressTemplateIndentation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* the value of `@aws-cdk/core:suppressTemplateIndentation`, or `false` if that is not set.
+
+Enable this flag to suppress indentation in generated CloudFormation templates.
+
+If not specified, the value of the `@aws-cdk/core:suppressTemplateIndentation`
+context key will be used. If that is not specified, then the
+default value `false` will be used.
 
 ---
 
@@ -10909,6 +10945,7 @@ const sqsToLambdaStageFunctionProps: SqsToLambdaStageFunctionProps = { ... }
 | <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.logRetentionRetryOptions">logRetentionRetryOptions</a></code> | <code>aws-cdk-lib.aws_lambda.LogRetentionRetryOptions</code> | When log retention is specified, a custom resource attempts to create the CloudWatch log group. |
 | <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.logRetentionRole">logRetentionRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM role for the Lambda function associated with the custom resource that sets the retention policy. |
 | <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.memorySize">memorySize</a></code> | <code>number</code> | The amount of memory, in MB, that is allocated to your Lambda function. |
+| <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.paramsAndSecrets">paramsAndSecrets</a></code> | <code>aws-cdk-lib.aws_lambda.ParamsAndSecretsLayerVersion</code> | Specify the configuration of Parameters and Secrets Extension. |
 | <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.profiling">profiling</a></code> | <code>boolean</code> | Enable profiling. |
 | <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.profilingGroup">profilingGroup</a></code> | <code>aws-cdk-lib.aws_codeguruprofiler.IProfilingGroup</code> | Profiling Group. |
 | <code><a href="#aws-ddk-core.SqsToLambdaStageFunctionProps.property.reservedConcurrentExecutions">reservedConcurrentExecutions</a></code> | <code>number</code> | The maximum of concurrent executions you want to reserve for the function. |
@@ -11323,6 +11360,21 @@ The amount of memory, in MB, that is allocated to your Lambda function.
 Lambda uses this value to proportionally allocate the amount of CPU
 power. For more information, see Resource Model in the AWS Lambda
 Developer Guide.
+
+---
+
+##### `paramsAndSecrets`<sup>Optional</sup> <a name="paramsAndSecrets" id="aws-ddk-core.SqsToLambdaStageFunctionProps.property.paramsAndSecrets"></a>
+
+```typescript
+public readonly paramsAndSecrets: ParamsAndSecretsLayerVersion;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.ParamsAndSecretsLayerVersion
+- *Default:* No Parameters and Secrets Extension
+
+Specify the configuration of Parameters and Secrets Extension.
+
+> [https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html](https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
     "organization": false
   },
   "devDependencies": {
-    "@aws-cdk/aws-glue-alpha": "2.80.0-alpha.0",
-    "@aws-cdk/aws-kinesisfirehose-alpha": "2.80.0-alpha.0",
-    "@aws-cdk/aws-kinesisfirehose-destinations-alpha": "2.80.0-alpha.0",
-    "@aws-cdk/integ-tests-alpha": "2.80.0-alpha.0",
+    "@aws-cdk/aws-glue-alpha": "2.85.0-alpha.0",
+    "@aws-cdk/aws-kinesisfirehose-alpha": "2.85.0-alpha.0",
+    "@aws-cdk/aws-kinesisfirehose-destinations-alpha": "2.85.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.85.0-alpha.0",
     "@types/jest": "^27",
     "@types/node": "^16",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.80.0",
+    "aws-cdk-lib": "2.85.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-config-prettier": "^8.8.0",
@@ -67,11 +67,11 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-glue-alpha": "^2.80.0-alpha.0",
-    "@aws-cdk/aws-kinesisfirehose-alpha": "^2.80.0-alpha.0",
-    "@aws-cdk/aws-kinesisfirehose-destinations-alpha": "^2.80.0-alpha.0",
-    "@aws-cdk/integ-tests-alpha": "^2.80.0-alpha.0",
-    "aws-cdk-lib": "^2.80.0",
+    "@aws-cdk/aws-glue-alpha": "^2.85.0-alpha.0",
+    "@aws-cdk/aws-kinesisfirehose-alpha": "^2.85.0-alpha.0",
+    "@aws-cdk/aws-kinesisfirehose-destinations-alpha": "^2.85.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "^2.85.0-alpha.0",
+    "aws-cdk-lib": "^2.85.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/src/pipelines/stage.ts
+++ b/src/pipelines/stage.ts
@@ -165,24 +165,23 @@ export abstract class DataStage extends Stage {
 
 function getDefinitionBody(definition?: sfn.IChainable | string, definitionFile?: string): sfn.DefinitionBody {
   if (definition && definitionFile) {
-    throw new Error("Only one of 'definition' or 'definitionFile' should be provided.")      
+    throw new Error("Only one of 'definition' or 'definitionFile' should be provided.");
   }
   if (!definition && !definitionFile) {
-    throw new Error("One of 'definition' or 'definitionFile' must be provided.")
+    throw new Error("One of 'definition' or 'definitionFile' must be provided.");
   }
 
   if (definitionFile) {
-    return sfn.DefinitionBody.fromFile(definitionFile, {})
-  }
-  else {
-    if (typeof definition == "string") { 
-      return sfn.DefinitionBody.fromString(definition) 
+    return sfn.DefinitionBody.fromFile(definitionFile, {});
+  } else {
+    if (typeof definition == "string") {
+      return sfn.DefinitionBody.fromString(definition);
     }
     if (definition) {
-      return sfn.DefinitionBody.fromChainable(definition)
+      return sfn.DefinitionBody.fromChainable(definition);
     }
   }
-  throw new Error("Not able to create a definition body.")
+  throw new Error("Not able to create a definition body.");
 }
 
 /**
@@ -190,10 +189,10 @@ function getDefinitionBody(definition?: sfn.IChainable | string, definitionFile?
  */
 export interface StateMachineStageProps extends StageProps {
   /**
-   * Steps for the state machine. 
+   * Steps for the state machine.
    * Can either be provided as 'sfn.IChainable' or a JSON string.
    */
-  readonly definition?: sfn.IChainable | string; 
+  readonly definition?: sfn.IChainable | string;
   /**
    * File containing a JSON definition for the state machine.
    */
@@ -258,7 +257,6 @@ export abstract class StateMachineStage extends DataStage {
    * @returns Dictionary with event pattern, targets and state machine construct.
    */
   protected createStateMachine(props: StateMachineStageProps): CreateStateMachineResult {
-    
     const stateMachine = new sfn.StateMachine(this, "State Machine", {
       definitionBody: getDefinitionBody(props.definition, props.definitionFile),
       stateMachineName: props.stateMachineName,

--- a/src/pipelines/stage.ts
+++ b/src/pipelines/stage.ts
@@ -163,10 +163,41 @@ export abstract class DataStage extends Stage {
   }
 }
 
+function getDefinitionBody(definition?: sfn.IChainable | string, definitionFile?: string): sfn.DefinitionBody {
+  if (definition && definitionFile) {
+    throw new Error("Only one of 'definition' or 'definitionFile' should be provided.")      
+  }
+  if (!definition && !definitionFile) {
+    throw new Error("One of 'definition' or 'definitionFile' must be provided.")
+  }
+
+  if (definitionFile) {
+    return sfn.DefinitionBody.fromFile(definitionFile, {})
+  }
+  else {
+    if (typeof definition == "string") { 
+      return sfn.DefinitionBody.fromString(definition) 
+    }
+    if (definition) {
+      return sfn.DefinitionBody.fromChainable(definition)
+    }
+  }
+  throw new Error("Not able to create a definition body.")
+}
+
 /**
  * Properties of a state machine stage.
  */
 export interface StateMachineStageProps extends StageProps {
+  /**
+   * Steps for the state machine. 
+   * Can either be provided as 'sfn.IChainable' or a JSON string.
+   */
+  readonly definition?: sfn.IChainable | string; 
+  /**
+   * File containing a JSON definition for the state machine.
+   */
+  readonly definitionFile?: string;
   /**
    * Input of the state machine.
    */
@@ -223,13 +254,13 @@ export abstract class StateMachineStage extends DataStage {
 
   /**
    * Constructs a state machine from the definition.
-   * @param definition Steps for the state machine.
    * @param props State machine stage properties.
    * @returns Dictionary with event pattern, targets and state machine construct.
    */
-  protected createStateMachine(definition: sfn.IChainable, props: StateMachineStageProps): CreateStateMachineResult {
+  protected createStateMachine(props: StateMachineStageProps): CreateStateMachineResult {
+    
     const stateMachine = new sfn.StateMachine(this, "State Machine", {
-      definition: definition,
+      definitionBody: getDefinitionBody(props.definition, props.definitionFile),
       stateMachineName: props.stateMachineName,
     });
 

--- a/src/stages/appflow-ingestion.ts
+++ b/src/stages/appflow-ingestion.ts
@@ -105,7 +105,7 @@ export class AppFlowIngestionStage extends StateMachineStage {
       eventPattern: this.eventPattern,
       targets: this.targets,
       stateMachine: this.stateMachine,
-    } = this.createStateMachine({definition: definition, ...props}));
+    } = this.createStateMachine({ definition: definition, ...props }));
     this.stateMachine.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/src/stages/appflow-ingestion.ts
+++ b/src/stages/appflow-ingestion.ts
@@ -105,7 +105,7 @@ export class AppFlowIngestionStage extends StateMachineStage {
       eventPattern: this.eventPattern,
       targets: this.targets,
       stateMachine: this.stateMachine,
-    } = this.createStateMachine(definition, props));
+    } = this.createStateMachine({definition: definition, ...props}));
     this.stateMachine.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/src/stages/athena-sql.ts
+++ b/src/stages/athena-sql.ts
@@ -102,7 +102,10 @@ export class AthenaSQLStage extends StateMachineStage {
 
     const definition = athenaQueryExec.next(new sfn.Succeed(this, "Success"));
 
-    ({ eventPattern: this.eventPattern, stateMachine: this.stateMachine } = this.createStateMachine({definition: definition, ...props}));
+    ({ eventPattern: this.eventPattern, stateMachine: this.stateMachine } = this.createStateMachine({
+      definition: definition,
+      ...props,
+    }));
     this.targets = [
       new eventsTargets.SfnStateMachine(this.stateMachine, {
         input: props.queryString

--- a/src/stages/athena-sql.ts
+++ b/src/stages/athena-sql.ts
@@ -102,7 +102,7 @@ export class AthenaSQLStage extends StateMachineStage {
 
     const definition = athenaQueryExec.next(new sfn.Succeed(this, "Success"));
 
-    ({ eventPattern: this.eventPattern, stateMachine: this.stateMachine } = this.createStateMachine(definition, props));
+    ({ eventPattern: this.eventPattern, stateMachine: this.stateMachine } = this.createStateMachine({definition: definition, ...props}));
     this.targets = [
       new eventsTargets.SfnStateMachine(this.stateMachine, {
         input: props.queryString

--- a/src/stages/databrew-transform.ts
+++ b/src/stages/databrew-transform.ts
@@ -192,7 +192,7 @@ export class DataBrewTransformStage extends StateMachineStage {
       eventPattern: this.eventPattern,
       targets: this.targets,
       stateMachine: this.stateMachine,
-    } = this.createStateMachine(definition, props));
+    } = this.createStateMachine({definition: definition, ...props}));
   }
 
   private createDefaultDataBrewJobRole(): iam.Role {

--- a/src/stages/databrew-transform.ts
+++ b/src/stages/databrew-transform.ts
@@ -192,7 +192,7 @@ export class DataBrewTransformStage extends StateMachineStage {
       eventPattern: this.eventPattern,
       targets: this.targets,
       stateMachine: this.stateMachine,
-    } = this.createStateMachine({definition: definition, ...props}));
+    } = this.createStateMachine({ definition: definition, ...props }));
   }
 
   private createDefaultDataBrewJobRole(): iam.Role {

--- a/src/stages/glue-transform.ts
+++ b/src/stages/glue-transform.ts
@@ -131,7 +131,7 @@ export class GlueTransformStage extends StateMachineStage {
       eventPattern: this.eventPattern,
       targets: this.targets,
       stateMachine: this.stateMachine,
-    } = this.createStateMachine({definition: definition, ...props}));
+    } = this.createStateMachine({ definition: definition, ...props }));
   }
 
   private getGlueJob(scope: Construct, id: string, props: GlueTransformStageProps): glue_alpha.IJob {

--- a/src/stages/glue-transform.ts
+++ b/src/stages/glue-transform.ts
@@ -131,7 +131,7 @@ export class GlueTransformStage extends StateMachineStage {
       eventPattern: this.eventPattern,
       targets: this.targets,
       stateMachine: this.stateMachine,
-    } = this.createStateMachine(definition, props));
+    } = this.createStateMachine({definition: definition, ...props}));
   }
 
   private getGlueJob(scope: Construct, id: string, props: GlueTransformStageProps): glue_alpha.IJob {

--- a/src/stages/mwaa-trigger-dags.ts
+++ b/src/stages/mwaa-trigger-dags.ts
@@ -95,7 +95,7 @@ export class MWAATriggerDagsStage extends StateMachineStage {
       eventPattern: this.eventPattern,
       targets: this.targets,
       stateMachine: this.stateMachine,
-    } = this.createStateMachine({definition: definition, ...props}));
+    } = this.createStateMachine({ definition: definition, ...props }));
   }
 
   private buildLambdas(): MWAALambdasResult {

--- a/src/stages/mwaa-trigger-dags.ts
+++ b/src/stages/mwaa-trigger-dags.ts
@@ -95,7 +95,7 @@ export class MWAATriggerDagsStage extends StateMachineStage {
       eventPattern: this.eventPattern,
       targets: this.targets,
       stateMachine: this.stateMachine,
-    } = this.createStateMachine(definition, props));
+    } = this.createStateMachine({definition: definition, ...props}));
   }
 
   private buildLambdas(): MWAALambdasResult {

--- a/src/stages/redshift-data-api.ts
+++ b/src/stages/redshift-data-api.ts
@@ -102,7 +102,7 @@ export class RedshiftDataApiStage extends StateMachineStage {
           .otherwise(wait),
       );
 
-    ({ eventPattern: this.eventPattern, stateMachine: this.stateMachine } = this.createStateMachine(definition, props));
+    ({ eventPattern: this.eventPattern, stateMachine: this.stateMachine } = this.createStateMachine({definition: definition, ...props}));
     this.stateMachine.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/src/stages/redshift-data-api.ts
+++ b/src/stages/redshift-data-api.ts
@@ -102,7 +102,10 @@ export class RedshiftDataApiStage extends StateMachineStage {
           .otherwise(wait),
       );
 
-    ({ eventPattern: this.eventPattern, stateMachine: this.stateMachine } = this.createStateMachine({definition: definition, ...props}));
+    ({ eventPattern: this.eventPattern, stateMachine: this.stateMachine } = this.createStateMachine({
+      definition: definition,
+      ...props,
+    }));
     this.stateMachine.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/test/base-stack.test.ts
+++ b/test/base-stack.test.ts
@@ -333,7 +333,7 @@ test("Test Permissions Boundary Creation and Usage in BaseStack", () => {
   const stackTemplate = Template.fromStack(stack);
   stackTemplate.hasResourceProperties("AWS::IAM::Role", {
     PermissionsBoundary: {
-      Ref: "DDKDefaultPermissionsBoundary6721F63A",
+      "Fn::ImportValue": "my-bootstrap-stack:ExportsOutputRefDDKDefaultPermissionsBoundary6721F63A9C9C311E",
     },
   });
 });

--- a/test/sfn-stage.test.ts
+++ b/test/sfn-stage.test.ts
@@ -1,0 +1,56 @@
+import * as cdk from "aws-cdk-lib";
+import * as events from "aws-cdk-lib/aws-events";
+import * as sfn from "aws-cdk-lib/aws-stepfunctions";
+import { Construct } from "constructs";
+
+import { StateMachineStage, StateMachineStageProps } from "../src";
+
+class TestSFNStage extends StateMachineStage {
+  readonly targets?: events.IRuleTarget[];
+  readonly eventPattern?: events.EventPattern;
+  readonly stateMachine: sfn.StateMachine;
+
+  constructor(scope: Construct, id: string, props: StateMachineStageProps) {
+    super(scope, id, props);
+    ({
+      eventPattern: this.eventPattern,
+      targets: this.targets,
+      stateMachine: this.stateMachine,
+    } = this.createStateMachine({
+      definition: props.definition,
+      definitionFile: props.definitionFile,
+      ...props,
+    }));
+  }
+}
+
+test("State Machine Stage Definition File", () => {
+  const stack = new cdk.Stack();
+  new TestSFNStage(stack, "MySFN", {
+    definitionFile: "./test/test-sfn-config.json",
+  });
+});
+
+test("State Machine Stage Definition String", () => {
+  const stack = new cdk.Stack();
+  new TestSFNStage(stack, "MySFN", {
+    definition: '{"StartAt":"Pass","States":{"Pass":{"Type":"Pass","End":true}}}',
+  });
+});
+
+test("SFN No Definition", () => {
+  const stack = new cdk.Stack();
+  expect(() => {
+    new TestSFNStage(stack, "MySFN", {});
+  }).toThrowError("One of 'definition' or 'definitionFile' must be provided.");
+});
+
+test("SFN Redundant Definitions", () => {
+  const stack = new cdk.Stack();
+  expect(() => {
+    new TestSFNStage(stack, "MySFN", {
+      definition: '{"StartAt":"Pass","States":{"Pass":{"Type":"Pass","End":true}}}',
+      definitionFile: "./test/test-sfn-config.json",
+    });
+  }).toThrowError("Only one of 'definition' or 'definitionFile' should be provided.");
+});

--- a/test/test-sfn-config.json
+++ b/test/test-sfn-config.json
@@ -1,0 +1,94 @@
+{
+  "StartAt": "random-number-generator-lambda-config",
+  "States": {
+
+
+    "random-number-generator-lambda-config": {
+      "Comment": "To configure the random-number-generator-lambda.",
+      "Type": "Pass",
+      "Result": {
+          "min": 1,
+          "max": 10
+        },
+      "ResultPath": "$",
+      "Next": "random-number-generator-lambda"
+    },
+    
+
+    "random-number-generator-lambda": {
+      "Comment": "Generate a number based on input.",
+      "Type": "Task",
+      "Resource": "${random-number-generator-lambda-aws-arn}",
+      "Next": "send-notification-if-less-than-5"
+    },
+
+
+    "send-notification-if-less-than-5": {
+      "Comment": "A choice state to decide to send out notification for <5 or trigger power of three lambda for >5.",
+      "Type": "Choice",
+      "Choices": [
+        {
+            "Variable": "$",
+            "NumericGreaterThanEquals": 5,
+            "Next": "power-of-three-lambda"
+        },
+        {
+          "Variable": "$",
+          "NumericLessThan": 5,
+          "Next": "send-multiple-notification"
+        }
+      ]
+    },
+
+
+    "power-of-three-lambda": {
+      "Comment": "Increase the input to power of 3 with customized input.",
+      "Type": "Task",
+      "Parameters" : {
+        "base.$": "$",
+        "exponent": 3
+      },
+      "Resource": "${power-of-number-lambda-aws-arn}",
+      "End": true
+    },
+
+
+    "send-multiple-notification": {
+      "Comment": "Trigger multiple notification using AWS SNS",
+      "Type": "Parallel",
+      "End": true,
+      "Branches": [
+        {
+         "StartAt": "send-sms-notification",
+         "States": {
+            "send-sms-notification": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "Message": "SMS: Random number is less than 5 $",
+                "PhoneNumber": "${valid-handphone-number}"
+              },
+              "End": true
+            }
+         }
+       },
+       {
+        "StartAt": "send-sns-topic",
+         "States": {
+           "send-sns-topic": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "Message": "Email: Random number is less than 5: $",
+                "TopicArn": "${aws-sns-topic-to-send-out-email}"
+              },
+              "End": true
+            }
+         }
+       }  
+      ]
+    }
+
+
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,25 +30,25 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz#c169599d83beceea7e638082ef9833997f04c85d"
   integrity sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg==
 
-"@aws-cdk/aws-glue-alpha@2.80.0-alpha.0":
-  version "2.80.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-glue-alpha/-/aws-glue-alpha-2.80.0-alpha.0.tgz#56d221c2ed6d110c2e51178c8911efbb87a14745"
-  integrity sha512-EL6ok3PVsm2rHn5HVqG6ekvty3NekwU2thqwmrylfg2qzeVOYww9iqXCrj85MNviWIccOlAAoeT62tOVZLFE+w==
+"@aws-cdk/aws-glue-alpha@2.85.0-alpha.0":
+  version "2.85.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-glue-alpha/-/aws-glue-alpha-2.85.0-alpha.0.tgz#98c9fe33452fa2ceadb17140c3b35da0101c944a"
+  integrity sha512-xCvDdpTjJPM7dI6n1wZaBnPpmG3bhHcFYqkoh6WJQ+7HY2WAIL08UqBT3iRaz3WSu0ZT6qyhQxzD+r63p+BKMw==
 
-"@aws-cdk/aws-kinesisfirehose-alpha@2.80.0-alpha.0":
-  version "2.80.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose-alpha/-/aws-kinesisfirehose-alpha-2.80.0-alpha.0.tgz#287cff047227ceed7e23f568c67439ddec76b937"
-  integrity sha512-nw885HQZPzKpR/ofUeY7ofZjPwsCkDsWCFPWa8dSHymUCKhUrBnUFClLS81IHfc7QGUPVz/O40S6nFfoFAFbLQ==
+"@aws-cdk/aws-kinesisfirehose-alpha@2.85.0-alpha.0":
+  version "2.85.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose-alpha/-/aws-kinesisfirehose-alpha-2.85.0-alpha.0.tgz#a9ccaeeace3748101bb53f208ecac2ff0d9b9566"
+  integrity sha512-DjNNw7lIoq6yGi4ME7EGumlkwvV+HPvKMyFkNu2nJYud025pnGofLSEzAVrkvCwzoauFoue6db+r+mj0fP+KXw==
 
-"@aws-cdk/aws-kinesisfirehose-destinations-alpha@2.80.0-alpha.0":
-  version "2.80.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose-destinations-alpha/-/aws-kinesisfirehose-destinations-alpha-2.80.0-alpha.0.tgz#c4bed0156fcb19080c14ea7e733e1a890b45a089"
-  integrity sha512-A+B4BQrymvpM896BVqqo3ATM2SzQUj/IqxIMxW4zQjZegjizsEh1kMAprERWdAHKqKByeDi69fR/EgQ9HPhdCQ==
+"@aws-cdk/aws-kinesisfirehose-destinations-alpha@2.85.0-alpha.0":
+  version "2.85.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose-destinations-alpha/-/aws-kinesisfirehose-destinations-alpha-2.85.0-alpha.0.tgz#5bab42d60718b5761159af4e9931d951ccce0a11"
+  integrity sha512-5nKBD5voMIxoJl/nTZ3WGeLG8glWHfCQgroOLI7pCYAz/M+mjcxlyuE8jUuvQZy+a1XMLVjpN2SdsfXZypDaTQ==
 
-"@aws-cdk/integ-tests-alpha@2.80.0-alpha.0":
-  version "2.80.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.80.0-alpha.0.tgz#d232c3885347336b9da0289c180675482c5d2a9f"
-  integrity sha512-XU5+8pqd2sUvxfyz6zluskydX1pY+NGL5jtZf2sUukkqN1PNQ/zZrQwyY6An8mCGggSwj0uMGrzItiuDKaiGuA==
+"@aws-cdk/integ-tests-alpha@2.85.0-alpha.0":
+  version "2.85.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.85.0-alpha.0.tgz#cf72248d3a0c2581eae13a8f190a33dbd5a913fc"
+  integrity sha512-tqURxQZnFYc0Quj58LOE7A2QoBxppPLwJgZalLBkhJgAsfARi42TU8uh14Ov/4Kk5KUEeL6pguyFy2xYvJSLCA==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.5":
   version "7.22.5"
@@ -1386,10 +1386,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.80.0:
-  version "2.80.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.80.0.tgz#1118860637d33fab8f646551c29a75728404b64e"
-  integrity sha512-PoqD3Yms5I0ajuTi071nTW/hpkH3XsdyZzn5gYsPv0qD7mqP3h6Qr+6RiGx+yQ1KcVFyxWdX15uK+DsC0KwvcQ==
+aws-cdk-lib@2.85.0:
+  version "2.85.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.85.0.tgz#09a577799b63107d3128c2755ee02acedc580e5d"
+  integrity sha512-u+ypK8XEMRH3tGRMSmcbPYxLet7xBdGIztUkMcPtlNJGhS/vxqh12yYkem3g3zzmHwdX8OPLSnlZ2sIuiIqp/g==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "^2.2.177"
     "@aws-cdk/asset-kubectl-v20" "^2.1.1"


### PR DESCRIPTION
### Changes
Allows for defining of SFN in three ways
1. `definition` : `stepfunction.IChainable` 
2. `definition` : `string` **JSON**
3. `definitionFile` : `string` **Path to JSON file**

These parameters are now conditionally optional meaning typescript would not allow for them to precede `props` in `createStateMachine()`. I think the best approach is to bring the parameters into the `StateMachineStageProps` interface.


#69 

 