### PR TITLE
fix: Making 'configPath' optional in interfaces 

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -303,25 +303,13 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
-        },
-        {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
-        },
-        {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
-        },
-        {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
-        },
-        {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
+          "exec": "npm-check-updates --upgrade --target=minor --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,eslint-config-prettier,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,npm-check-updates,prettier,projen,standard-version,ts-jest,typescript,ts-node,yaml,@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade"
+          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak npm-check-updates prettier projen standard-version ts-jest typescript ts-node yaml @aws-cdk/aws-glue-alpha @aws-cdk/aws-kinesisfirehose-alpha @aws-cdk/aws-kinesisfirehose-destinations-alpha @aws-cdk/integ-tests-alpha aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -303,13 +303,25 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --upgrade --target=minor --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,eslint-config-prettier,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,npm-check-updates,prettier,projen,standard-version,ts-jest,typescript,ts-node,yaml,@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
+        },
+        {
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
+        },
+        {
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
+        },
+        {
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
+        },
+        {
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-glue-alpha,@aws-cdk/aws-kinesisfirehose-alpha,@aws-cdk/aws-kinesisfirehose-destinations-alpha,@aws-cdk/integ-tests-alpha,aws-cdk-lib,constructs,jsii-rosetta,jsii,deepmerge'"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak npm-check-updates prettier projen standard-version ts-jest typescript ts-node yaml @aws-cdk/aws-glue-alpha @aws-cdk/aws-kinesisfirehose-alpha @aws-cdk/aws-kinesisfirehose-destinations-alpha @aws-cdk/integ-tests-alpha aws-cdk-lib constructs"
+          "exec": "yarn upgrade"
         },
         {
           "exec": "npx projen"

--- a/API.md
+++ b/API.md
@@ -9999,7 +9999,7 @@ const getEnvironmentProps: GetEnvironmentProps = { ... }
 
 ---
 
-##### `configPath`<sup>Required</sup> <a name="configPath" id="aws-ddk-core.GetEnvironmentProps.property.configPath"></a>
+##### `configPath`<sup>Optional</sup> <a name="configPath" id="aws-ddk-core.GetEnvironmentProps.property.configPath"></a>
 
 ```typescript
 public readonly configPath: string;
@@ -10182,7 +10182,7 @@ const getTagsProps: GetTagsProps = { ... }
 
 ---
 
-##### `configPath`<sup>Required</sup> <a name="configPath" id="aws-ddk-core.GetTagsProps.property.configPath"></a>
+##### `configPath`<sup>Optional</sup> <a name="configPath" id="aws-ddk-core.GetTagsProps.property.configPath"></a>
 
 ```typescript
 public readonly configPath: string;

--- a/src/config/configurator.ts
+++ b/src/config/configurator.ts
@@ -209,7 +209,7 @@ export interface GetTagsProps {
   /**
    * Relative path to config file. Defaults to './ddk.json'
    */
-  readonly configPath: string;
+  readonly configPath?: string;
   /**
    * Environment identifier
    */
@@ -220,7 +220,7 @@ export interface GetEnvironmentProps {
   /**
    * Relative path to config file. Defaults to './ddk.json'
    */
-  readonly configPath: string;
+  readonly configPath?: string;
   /**
    * Environment identifier.
    */
@@ -239,7 +239,8 @@ export class Configurator {
   }
 
   public static getTags(props: GetTagsProps): { [key: string]: string } {
-    const config = getConfig({ config: props.configPath });
+    const configPath = props.configPath ?? "./ddk.json";
+    const config = getConfig({ config: configPath });
 
     if (!config || !config.environments) {
       throw TypeError("Config not defined.");
@@ -257,7 +258,8 @@ export class Configurator {
   }
 
   public static getEnvironment(props: GetEnvironmentProps): cdk.Environment {
-    const config = getConfig({ config: props.configPath });
+    const configPath = props.configPath ?? "./ddk.json";
+    const config = getConfig({ config: configPath });
 
     if (!config) {
       throw TypeError("Config not defined.");


### PR DESCRIPTION
Closes #416

## Fix
Making `configPath` optional in interfaces:
- `GetTagsProps`
- `GetEnvironmentProps`