### PR TITLE
feat: Update MWAATriggerDagsStage to pass json event to MWAA airflow dag

### DIFF
--- a/src/stages/mwaa-trigger-dags.ts
+++ b/src/stages/mwaa-trigger-dags.ts
@@ -70,7 +70,7 @@ export class MWAATriggerDagsStage extends StateMachineStage {
     definition.branch(
       new tasks.LambdaInvoke(this, "Trigger Dag", {
         lambdaFunction: lambdas.triggerLambda,
-        payload: sfn.TaskInput.fromObject({ dag_ids: dagIds }),
+        payload: sfn.TaskInput.fromObject({ dag_ids: dagIds, body: sfn.JsonPath.objectAt("$") }),
         resultPath: sfn.JsonPath.DISCARD,
       })
         .next(waitTask)
@@ -162,8 +162,9 @@ def lambda_handler(event, context):
       'Content-Type': 'text/plain'
     }
 
+    event_body = json.dumps(event["body"])
     for dag_id in event['dag_ids']:
-      run_api_call(conn, f"dags trigger {dag_id}", headers)
+      run_api_call(conn, f"dags trigger {dag_id} --conf '{event_body}'", headers)
         `),
       handler: "index.lambda_handler",
       role: lambdaRole,


### PR DESCRIPTION
### Description
Currently, MWAATriggerDagStage does not pass the sfn event to the MWAA dag. This enhancement enables to pass runtime parameters/sfn event when triggering dag. The parameters can be accessed from the dag_run.conf.  

### Changes Made

Changes made to MWAATriggerDagStage:

1) Trigger dag lambda has an additional payload of the sfn event passed in body
2) airflow command updated to pass sfn event to MWAA dag using --conf   


### Related Issue
#428
