### PR TITLE
fix: Restrict MWAA Env to Two Subnets

### DIFF
--- a/src/core/mwaa-environment.ts
+++ b/src/core/mwaa-environment.ts
@@ -230,7 +230,10 @@ export class MWAAEnvironment extends Construct {
       dagS3Path: this.dagS3Path,
       networkConfiguration: {
         securityGroupIds: [securityGroup.securityGroupId],
-        subnetIds: this.vpc.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS }).subnetIds,
+        subnetIds: [
+          this.vpc.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS }).subnetIds[0],
+          this.vpc.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS }).subnetIds[1],
+        ],
       },
       webserverAccessMode: "PUBLIC_ONLY",
       loggingConfiguration: {


### PR DESCRIPTION
Using MWAA Environment with `createVpc()` sometimes results in an invalid subnet amount error.

```
#/NetworkConfiguration/SubnetIds: expected maximum item count: 2, found: 3
```

Restricting MWAA creation to two private subnets per [AWS::MWAA::Environment NetworkConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-networkconfiguration.html)