### PR TITLE
chore: Reduce dependency upgrade frequency to weekly

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -34,6 +34,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
   name: "aws-ddk-core",
   repositoryUrl: "https://github.com/awslabs/aws-ddk/tree/main",
 
+  depsUpgradeOptions: {
+    workflowOptions: {
+      schedule: javascript.UpgradeDependenciesSchedule.WEEKLY,
+    },
+  },
+
   // Artifact config: Python
   publishToPypi: {
     distName: "aws-ddk-core",


### PR DESCRIPTION
I feel like we don't need to have our dependencies upgrading daily, especially as our release candency approx. monthly 😄 